### PR TITLE
[PAR-3823] conditionally call orders create endpoint when order is new

### DIFF
--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -76,7 +76,7 @@ class SalesOrderSaveAfter implements ObserverInterface
      */
     private function resolveEndpoint(OrderInterface $order): array
     {
-      if ($order->isObjectNew()) {
+      if (!$order->getOriginalIncrementId()) {
         return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_create'], 'type' => 'middleware'];
       }
 

--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -59,7 +59,7 @@ class SalesOrderSaveAfter implements ObserverInterface
         $orderCreatedAt = $order->getCreatedAt();
         $orderUpdatedAt = $order->getUpdatedAt();
 
-        if ($orderCreatedAt != $orderUpdatedAt) {
+        if ($orderCreatedAt !== $orderUpdatedAt) {
             try {
                 $this->orderObserverHandler->execute(
                     ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_update'], 'type' => 'middleware'],

--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -76,10 +76,12 @@ class SalesOrderSaveAfter implements ObserverInterface
      */
     private function resolveEndpoint(OrderInterface $order): array
     {
-      if (!$order->getOriginalIncrementId()) {
-        return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_create'], 'type' => 'middleware'];
-      }
+        $createdAt = $order->getCreatedAt();
+        $updatedAt = $order->getUpdatedAt();
+        if ($createdAt == $updatedAt) {
+          return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_create'], 'type' => 'middleware'];
+        }
 
-      return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_update'], 'type' => 'middleware'];
+        return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_update'], 'type' => 'middleware'];
     }
 }

--- a/Test/Unit/Observer/SalesOrderSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderSaveAfterTest.php
@@ -96,10 +96,6 @@ class SalesOrderSaveAfterTest extends TestCase
       $this->orderMock = $this->getMockBuilder(Order::class)
         ->onlyMethods(['getCreatedAt', 'getUpdatedAt'])->disableOriginalConstructor()
         ->getMock();
-      $mockCreateDate = '2021-01-01 00:00:00';
-      $mockUpdateDate = '2021-02-03 00:00:00';
-      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockCreateDate);
-      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockUpdateDate);
       $this->event = $this->getMockBuilder(Event::class)
           ->addMethods(['getOrder'])
           ->disableOriginalConstructor()
@@ -119,7 +115,20 @@ class SalesOrderSaveAfterTest extends TestCase
       );
     }
 
-    public function testExecutesOrdersObserver() {
+    public function testExecutesOrdersCreateHandlerWhenOrderIsBeingCreated() {
+      $mockCreateDate = '2021-01-01 00:00:00';
+      $mockUpdateDate = '2021-01-01 00:00:00';
+      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockCreateDate);
+      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockUpdateDate);
+      $this->orderObserverHandler->expects($this->never())->method('execute');
+      $this->import->execute($this->observer);
+    }
+
+    public function testExecutesOrdersObserveHandlerWhenOrderIsBeingUpdated() {
+      $mockCreateDate = '2021-01-01 00:00:00';
+      $mockUpdateDate = '2021-02-03 00:00:00';
+      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockCreateDate);
+      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockUpdateDate);
       $this->orderObserverHandler->expects($this->once())
           ->method('execute')
           ->with(
@@ -131,6 +140,10 @@ class SalesOrderSaveAfterTest extends TestCase
     }
 
     public function testLogsErrorsToLoggingService() {
+      $mockCreateDate = '2021-01-01 00:00:00';
+      $mockUpdateDate = '2021-02-03 00:00:00';
+      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockCreateDate);
+      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockUpdateDate);
       $this->orderObserverHandler->expects($this->once())
           ->method('execute')
           ->willThrowException(new Exception());

--- a/Test/Unit/Observer/SalesOrderSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderSaveAfterTest.php
@@ -96,9 +96,10 @@ class SalesOrderSaveAfterTest extends TestCase
       $this->orderMock = $this->getMockBuilder(Order::class)
         ->onlyMethods(['getCreatedAt', 'getUpdatedAt'])->disableOriginalConstructor()
         ->getMock();
-      $mockDate = '2021-01-01 00:00:00';
-      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockDate);
-      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockDate);
+      $mockCreateDate = '2021-01-01 00:00:00';
+      $mockUpdateDate = '2021-02-03 00:00:00';
+      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockCreateDate);
+      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockUpdateDate);
       $this->event = $this->getMockBuilder(Event::class)
           ->addMethods(['getOrder'])
           ->disableOriginalConstructor()
@@ -122,7 +123,7 @@ class SalesOrderSaveAfterTest extends TestCase
       $this->orderObserverHandler->expects($this->once())
           ->method('execute')
           ->with(
-              $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_create'], 'type' => 'middleware']),
+              $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_update'], 'type' => 'middleware']),
               $this->equalTo($this->orderMock),
               $this->equalTo([])
           );

--- a/Test/Unit/Observer/SalesOrderSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderSaveAfterTest.php
@@ -93,7 +93,12 @@ class SalesOrderSaveAfterTest extends TestCase
           ->getMockForAbstractClass();
       $this->storeManager->expects($this->any())->method('getStore')
           ->willReturn($this->store);
-      $this->orderMock = $this->createMock(Order::class);
+      $this->orderMock = $this->getMockBuilder(Order::class)
+        ->onlyMethods(['getCreatedAt', 'getUpdatedAt'])->disableOriginalConstructor()
+        ->getMock();
+      $mockDate = '2021-01-01 00:00:00';
+      $this->orderMock->expects($this->any())->method('getCreatedAt')->willReturn($mockDate);
+      $this->orderMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockDate);
       $this->event = $this->getMockBuilder(Event::class)
           ->addMethods(['getOrder'])
           ->disableOriginalConstructor()
@@ -117,7 +122,7 @@ class SalesOrderSaveAfterTest extends TestCase
       $this->orderObserverHandler->expects($this->once())
           ->method('execute')
           ->with(
-              $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_update'], 'type' => 'middleware']),
+              $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_orders_create'], 'type' => 'middleware']),
               $this->equalTo($this->orderMock),
               $this->equalTo([])
           );


### PR DESCRIPTION
### Details
* Copied logic found in Observer/CatalogProductSaveEntityAfter.php to conditionally make a request to webhooks_orders_update
* Updated logic to compare `createdAt` and `updatedAt` timestamps for the order object to determine if the observed event was emitted from an order create vs. order update
* Manual test pending
* UT updated