### PR TITLE
[PAR-3825] fix shipment request

### DIFF
--- a/Observer/SalesOrderShipmentSaveAfter.php
+++ b/Observer/SalesOrderShipmentSaveAfter.php
@@ -11,7 +11,6 @@ use Extend\Integration\Service\Api\ShipmentObserverHandler;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Sales\Model\Order\Shipment;
 use Psr\Log\LoggerInterface;
 
 class SalesOrderShipmentSaveAfter implements ObserverInterface
@@ -56,25 +55,12 @@ class SalesOrderShipmentSaveAfter implements ObserverInterface
   {
     try {
       $shipment = $observer->getEvent()->getShipment();
-      $endpoint = $this->resolveEndpoint($shipment);
+      $endpoint = ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'];
       $this->shipmentObserverHandler->execute($endpoint, $shipment, []);
     } catch (\Exception $exception) {
       // silently handle errors
       $this->logger->error('Extend Order Observer Handler encountered the following error: ' . $exception->getMessage());
       $this->integration->logErrorToLoggingService($exception->getMessage(), $this->storeManager->getStore()->getId(), 'error');
     }
-  }
-
-  /**
-   * @param Shipment $shipment
-   * @return array
-   */
-  private function resolveEndpoint($shipment): array
-  {
-    if (!$shipment->getIncrementId()) {
-      return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'];
-    }
-
-    return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware'];
   }
 }

--- a/Observer/SalesOrderShipmentSaveAfter.php
+++ b/Observer/SalesOrderShipmentSaveAfter.php
@@ -11,6 +11,7 @@ use Extend\Integration\Service\Api\ShipmentObserverHandler;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Sales\Model\Order\Shipment;
 use Psr\Log\LoggerInterface;
 
 class SalesOrderShipmentSaveAfter implements ObserverInterface
@@ -55,24 +56,25 @@ class SalesOrderShipmentSaveAfter implements ObserverInterface
   {
     try {
       $shipment = $observer->getEvent()->getShipment();
-
-      if ($shipment->isObjectNew()) {
-        $this->shipmentObserverHandler->execute(
-          ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'],
-          $shipment,
-          []
-        );
-      } else {
-        $this->shipmentObserverHandler->execute(
-          ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware'],
-          $shipment,
-          []
-        );
-      }
+      $endpoint = $this->resolveEndpoint($shipment);
+      $this->shipmentObserverHandler->execute($endpoint, $shipment, []);
     } catch (\Exception $exception) {
       // silently handle errors
       $this->logger->error('Extend Order Observer Handler encountered the following error: ' . $exception->getMessage());
       $this->integration->logErrorToLoggingService($exception->getMessage(), $this->storeManager->getStore()->getId(), 'error');
     }
+  }
+
+  /**
+   * @param Shipment $shipment
+   * @return array
+   */
+  private function resolveEndpoint($shipment): array
+  {
+    if (!$shipment->getIncrementId()) {
+      return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'];
+    }
+
+    return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware'];
   }
 }

--- a/Observer/SalesOrderShipmentSaveAfter.php
+++ b/Observer/SalesOrderShipmentSaveAfter.php
@@ -11,6 +11,7 @@ use Extend\Integration\Service\Api\ShipmentObserverHandler;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Sales\Model\Order\Shipment;
 use Psr\Log\LoggerInterface;
 
 class SalesOrderShipmentSaveAfter implements ObserverInterface
@@ -55,12 +56,28 @@ class SalesOrderShipmentSaveAfter implements ObserverInterface
   {
     try {
       $shipment = $observer->getEvent()->getShipment();
-      $endpoint = ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'];
+      $endpoint = $this->resolveEndpoint($shipment);
       $this->shipmentObserverHandler->execute($endpoint, $shipment, []);
     } catch (\Exception $exception) {
       // silently handle errors
-      $this->logger->error('Extend Order Observer Handler encountered the following error: ' . $exception->getMessage());
+      $this->logger->error('Extend Shipment Observer Handler encountered the following error: ' . $exception->getMessage());
       $this->integration->logErrorToLoggingService($exception->getMessage(), $this->storeManager->getStore()->getId(), 'error');
     }
+  }
+
+  /**
+   * @param Shipment $shipment
+   * @return array
+   */
+  private function resolveEndpoint($shipment): array
+  {
+    $createdAt = $shipment->getCreatedAt();
+    $updatedAt = $shipment->getUpdatedAt();
+
+    if ($createdAt === $updatedAt) {
+      return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware'];
+    }
+
+    return ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware'];
   }
 }

--- a/Service/Api/Integration.php
+++ b/Service/Api/Integration.php
@@ -84,7 +84,13 @@ class Integration
             $this->logger->info('Curl request to ' . $fullUrl . ' provided the following response: ' . $response);
 
             if ($status >= 400) {
-                $this->logErrorToLoggingService($response, $this->storeManager->getStore()->getId(), 'error');
+                $errorMessage = 'Curl request to ' . $fullUrl . ' provided the following unsuccessful response: ' . $response;
+                
+                $this->logErrorToLoggingService(
+                    $errorMessage,
+                    $this->storeManager->getStore()->getId(),
+                    'error'
+                );
             }
 
             if ($getBody) {

--- a/Service/Api/Integration.php
+++ b/Service/Api/Integration.php
@@ -21,7 +21,7 @@ class Integration
         'webhooks_orders_cancel' => '/webhooks/orders/cancel',
         'webhooks_orders_update' => '/webhooks/orders/update',
         'webhooks_shipments_create' => '/webhooks/shipments/create',
-        'webhooks_shipments_update' => '/webhooks/shipment/update',
+        'webhooks_shipments_update' => '/webhooks/shipments/update',
         'webhooks_products_create' => '/webhooks/products/create',
         'webhooks_products_update' => '/webhooks/products/update',
         'webhooks_products_delete' => '/webhooks/products/delete',

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -95,7 +95,7 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
     $this->shipmentMock = $this->getMockBuilder(Shipment::class)
-      ->setMethods(['getIncrementId'])
+      ->onlyMethods(['getIncrementId'])
       ->disableOriginalConstructor()
       ->getMock();
     $this->shipmentMock->expects($this->any())->method('getIncrementId')->willReturn(null);

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -94,7 +94,7 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
       ->getMockForAbstractClass();
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
-    $this->shipmentMock = $this->createMock(Shipment::class)
+    $this->shipmentMock = $this->getMockBuilder(Shipment::class)
       ->setMethods(['getIncrementId'])
       ->disableOriginalConstructor()
       ->getMock();

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -94,7 +94,12 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
       ->getMockForAbstractClass();
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
-    $this->shipmentMock = $this->getMockBuilder(Shipment::class)->getMock();
+    $this->shipmentMock = $this->getMockBuilder(Shipment::class)
+      ->onlyMethods(['getCreatedAt', 'getUpdatedAt'])->disableOriginalConstructor()
+      ->getMock();
+    $mockDate = '2021-01-01 00:00:00';
+    $this->shipmentMock->expects($this->any())->method('getCreatedAt')->willReturn($mockDate);
+    $this->shipmentMock->expects($this->any())->method('getUpdatedAt')->willReturn($mockDate);
     $this->event = $this->getMockBuilder(Event::class)
       ->addMethods(['getShipment'])
       ->disableOriginalConstructor()

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -94,7 +94,11 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
       ->getMockForAbstractClass();
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
-    $this->shipmentMock = $this->createMock(Shipment::class);
+    $this->shipmentMock = $this->createMock(Shipment::class)
+      ->addMethods(['getIncrementId'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->shipmentMock->expects($this->any())->method('getIncrementId')->willReturn(null);
     $this->event = $this->getMockBuilder(Event::class)
       ->addMethods(['getShipment'])
       ->disableOriginalConstructor()
@@ -119,7 +123,7 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
     $this->shipmentObserverHandler->expects($this->once())
       ->method('execute')
       ->with(
-        $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware']),
+        $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_create'], 'type' => 'middleware']),
         $this->equalTo($this->shipmentMock),
         $this->equalTo([])
       );

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -94,11 +94,7 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
       ->getMockForAbstractClass();
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
-    $this->shipmentMock = $this->getMockBuilder(Shipment::class)
-      ->onlyMethods(['getIncrementId'])
-      ->disableOriginalConstructor()
-      ->getMock();
-    $this->shipmentMock->expects($this->any())->method('getIncrementId')->willReturn(null);
+    $this->shipmentMock = $this->getMockBuilder(Shipment::class)->getMock();
     $this->event = $this->getMockBuilder(Event::class)
       ->addMethods(['getShipment'])
       ->disableOriginalConstructor()

--- a/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentSaveAfterTest.php
@@ -95,7 +95,7 @@ class SalesOrderShipmentSaveAfterTest extends TestCase
     $this->storeManager->expects($this->any())->method('getStore')
       ->willReturn($this->store);
     $this->shipmentMock = $this->createMock(Shipment::class)
-      ->addMethods(['getIncrementId'])
+      ->setMethods(['getIncrementId'])
       ->disableOriginalConstructor()
       ->getMock();
     $this->shipmentMock->expects($this->any())->method('getIncrementId')->willReturn(null);


### PR DESCRIPTION
Couple fixes here, firstly we were always calling shipment update, similar to the order bug, but because the `isObjectNew` method on the shipment always returned false, and this is how we were determining if the shipment was new versus existing. Second, we defined the shipment update endpoint incorrectly so we were hitting an endpoint that didn't exist which  somehow resulted in a 403 versus a 404.