### PR TITLE
PAR-3730 Use Extend Store ID From the old Guidance Module if it already exists

### DIFF
--- a/Block/Adminhtml/Integration/Edit/Tab/Stores.php
+++ b/Block/Adminhtml/Integration/Edit/Tab/Stores.php
@@ -174,7 +174,9 @@ class Stores extends \Magento\Backend\Block\Widget\Form\Generic implements \Mage
         $stores = $this->storeRepository->getList();
 
         foreach ($stores as $store) {
-            $options[] = ['value' => $store->getStoreId(), 'label' => $store->getName()];
+            if ($store->getCode() !== 'admin') {
+                $options[] = ['value' => $store->getStoreId(), 'label' => $store->getName()];
+            }
         }
 
         return $options;

--- a/Model/StoreIntegrationRepository.php
+++ b/Model/StoreIntegrationRepository.php
@@ -187,8 +187,8 @@ class StoreIntegrationRepository implements \Extend\Integration\Api\StoreIntegra
             $this->storeIntegrationResource->save($storeIntegration);
         } else {
             $storeCode = $this->storeManager->getStore($storeId)->getCode();
-            $legacyExtendProductionStoreId = $this->scopeConfig->getValue(self::LEGACY_EXTEND_MODULE_PRODUCTION_STORE_ID, $this->scopeConfig::SCOPE_STORES, $storeCode);
-            $legacyExtendSandboxStoreId = $this->scopeConfig->getValue(self::LEGACY_EXTEND_MODULE_SANDBOX_STORE_ID, $this->scopeConfig::SCOPE_STORES, $storeCode);
+            $legacyExtendProductionStoreId = $this->scopeConfig->getValue(self::LEGACY_EXTEND_MODULE_PRODUCTION_STORE_ID, 'store', $storeCode);
+            $legacyExtendSandboxStoreId = $this->scopeConfig->getValue(self::LEGACY_EXTEND_MODULE_SANDBOX_STORE_ID, 'store', $storeCode);
             $integration = $this->integrationService->get($integrationId);
             $environment = $this->activeEnvironmentURLBuilder->getEnvironmentFromURL($integration->getEndpoint());
             $storeIntegration = $this->storeIntegrationFactory->create();

--- a/Service/Api/ActiveEnvironmentURLBuilder.php
+++ b/Service/Api/ActiveEnvironmentURLBuilder.php
@@ -62,13 +62,19 @@ class ActiveEnvironmentURLBuilder {
         return 'https://api' . $environment . '.helloextend.com';
     }
 
-    private static function isProductionURL(string $url): bool {
+    private function isProductionURL(string $url): bool {
         return substr_count($url, '-') < 2;
     }
 
-    private static function getEnvironmentFromURL(string $url): string {
-        $urlParts = explode('https://integ-mage-', $url);
-        $urlParts = explode('.', $urlParts[1]);
-        return $urlParts[0];
+    public function getEnvironmentFromURL(string $url): string {
+        if (str_contains($url, 'https://integ-mage-')) {
+            $urlParts = explode('https://integ-mage-', $url);
+            $urlParts = explode('.', $urlParts[1]);
+            return $urlParts[0];
+        }
+        if (str_contains($url, 'https://integ-mage.')) {
+            return 'prod';
+        }
+        return '';
     }
 }

--- a/Service/Api/ActiveEnvironmentURLBuilder.php
+++ b/Service/Api/ActiveEnvironmentURLBuilder.php
@@ -63,7 +63,7 @@ class ActiveEnvironmentURLBuilder {
     }
 
     private function isProductionURL(string $url): bool {
-        return substr_count($url, '-') < 2;
+        return $this->getEnvironmentFromURL($url) === 'prod';
     }
 
     public function getEnvironmentFromURL(string $url): string {


### PR DESCRIPTION
This code fires off an additional check when saving stores to an integration.  It looks into the core_config_data table where the Guidance module saves the prod and demo (called 'sandbox') for each store, and if it finds values it uses that as the Extend store id for the same store instead of having NodeCore generate a new one. This would also link it to a store that already exists in Extend instead of creating a new Extend store (but that happens on the NodeCore side of things).