### PR TITLE
[PAR-3906] fixed env resolve logic for prod urls

### DIFF
--- a/ViewModel/EnvironmentAndExtendStoreUuid.php
+++ b/ViewModel/EnvironmentAndExtendStoreUuid.php
@@ -34,10 +34,8 @@ class EnvironmentAndExtendStoreUuid implements \Magento\Framework\View\Element\B
     public function getActiveEnvironment()
     {
         $activeEnvironmentUrl = $this->activeEnvironmentURLBuilder->getIntegrationURL();
-        $urlParts = explode("integ-mage", $activeEnvironmentUrl);
-        $activeEnvironment = explode(".extend.com", $urlParts[1]);
 
-        return $activeEnvironment[0] ? str_replace("-", "", $activeEnvironment[0]) : 'prod';
+        return $this->activeEnvironmentURLBuilder->getEnvironmentFromURL($activeEnvironmentUrl);
     }
 
     public function getExtendStoreUuid(): ?string


### PR DESCRIPTION
We had logic that assumed all integration urls contained an environment, this is not the case for prod. We had prod integration settings toggled so it was trying to resolve the env from the prod integration url. Can go to checkout with any integration settings toggled now, the offer will only render if the toggled integration matches an active one, but doesn't break the page if not.