### PR TITLE
[PAR-3966] add shipment track delete observer

### DIFF
--- a/Observer/SalesOrderShipmentTrackDeleteAfter.php
+++ b/Observer/SalesOrderShipmentTrackDeleteAfter.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright Extend (c) 2022. All rights reserved.
+ * See Extend-COPYING.txt for license details.
+ */
+
+namespace Extend\Integration\Observer;
+
+use Extend\Integration\Service\Api\Integration;
+use Extend\Integration\Service\Api\ShipmentObserverHandler;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Sales\Model\Order\Shipment;
+use Magento\Sales\Model\Order\Shipment\Track;
+use Psr\Log\LoggerInterface;
+
+class SalesOrderShipmentTrackDeleteAfter implements ObserverInterface
+{
+  /**
+   * @var LoggerInterface
+   */
+  private $logger;
+
+  /**
+   * @var ShipmentObserverHandler
+   */
+  private $shipmentObserverHandler;
+
+  /**
+   * @var Integration
+   */
+  private $integration;
+
+  /**
+   * @var StoreManagerInterface
+   */
+  private $storeManager;
+
+  public function __construct(
+    LoggerInterface $logger,
+    ShipmentObserverHandler $shipmentObserverHandler,
+    Integration $integration,
+    StoreManagerInterface $storeManager
+  ) {
+    $this->logger = $logger;
+    $this->shipmentObserverHandler = $shipmentObserverHandler;
+    $this->integration = $integration;
+    $this->storeManager = $storeManager;
+  }
+
+  /**
+   * @param Observer $observer
+   * @return void
+   */
+  public function execute(Observer $observer)
+  {
+    try {
+      /** @var Track */
+      $track = $observer->getEvent()->getTrack();
+      /** @var Shipment */
+      $shipment = $track->getShipment();
+      $endpoint = ['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware'];
+      $this->shipmentObserverHandler->execute($endpoint, $shipment, []);
+    } catch (\Exception $exception) {
+      // silently handle errors
+      $this->logger->error('Extend Shipment Observer Handler encountered the following error: ' . $exception->getMessage());
+      $this->integration->logErrorToLoggingService($exception->getMessage(), $this->storeManager->getStore()->getId(), 'error');
+    }
+  }
+}

--- a/Test/Unit/Observer/SalesOrderShipmentTrackDeleteAfterTest.php
+++ b/Test/Unit/Observer/SalesOrderShipmentTrackDeleteAfterTest.php
@@ -1,0 +1,153 @@
+<?php
+/*
+ * Copyright Extend (c) 2022. All rights reserved.
+ * See Extend-COPYING.txt for license details.
+ */
+
+namespace Extend\Integration\Test\Unit\Observer;
+
+use Extend\Integration\Service\Api\Integration;
+use Extend\Integration\Service\Api\ShipmentObserverHandler;
+use Extend\Integration\Observer\SalesOrderShipmentTrackDeleteAfter;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Store;
+use Magento\Sales\Model\Order\Shipment;
+use Magento\Sales\Model\Order\Shipment\Track;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Exception;
+
+class SalesOrderShipmentTrackDeleteAfterTest extends TestCase
+{
+  /**
+   * @var LoggerInterface
+   */
+  private $logger;
+
+  /**
+   * @var SalesOrderShipmentTrackDeleteAfter
+   */
+  private $import;
+
+  /**
+   * @var StoreManagerInterface|MockObject
+   */
+  private $storeManager;
+
+  /**
+   * @var Store|MockObject
+   */
+  private $store;
+
+  /**
+   * @var ShipmentObserverHandler|MockObject
+   */
+  private $shipmentObserverHandler;
+
+  /**
+   * @var Integration|MockObject
+   */
+  private $integration;
+
+  /**
+   * @var Track|MockObject
+   */
+  private $trackMock;
+
+  /**
+   * @var Shipment|MockObject
+   */
+  private $shipmentMock;
+
+  /**
+   * @var Observer|MockObject
+   */
+  private $observer;
+
+  /**
+   * @var Event|MockObject
+   */
+  private $event;
+
+
+  /**
+   * @var ObjectManager
+   */
+  protected $objectManager;
+
+  protected function setUp(): void
+  {
+    $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+    $this->shipmentObserverHandler = $this->getMockBuilder(ShipmentObserverHandler::class)
+      ->setMethods(['execute'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->integration = $this->getMockBuilder(
+      Integration::class
+    )->disableOriginalConstructor()
+      ->getMock();
+    $this->store = $this->getMockBuilder(Store::class)
+      ->setMethods(['getId'])
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+    $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
+      ->setMethods(['getStore'])
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+    $this->storeManager->expects($this->any())->method('getStore')
+      ->willReturn($this->store);
+    $this->shipmentMock = $this->getMockBuilder(Shipment::class)
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+    $this->trackMock = $this->getMockBuilder(Track::class)
+      ->setMethods(['getShipment'])
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+    $this->trackMock->expects($this->any())->method('getShipment')->willReturn($this->shipmentMock);
+    $this->event = $this->getMockBuilder(Event::class)
+      ->addMethods(['getTrack'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->event->expects($this->any())->method('getTrack')->willReturn($this->trackMock);
+    $this->observer = $this->createPartialMock(Observer::class, ['getEvent']);
+    $this->observer->expects($this->any())->method('getEvent')->willReturn($this->event);
+    $this->objectManager = new ObjectManager($this);
+    $this->import = $this->objectManager->getObject(
+      SalesOrderShipmentTrackDeleteAfter::class,
+      [
+        'logger' => $this->logger,
+        'shipmentObserverHandler' => $this->shipmentObserverHandler,
+        'integration' => $this->integration,
+        'storeManager' => $this->storeManager,
+      ]
+    );
+  }
+
+  public function testExecutesShipmentObserver()
+  {
+    $this->shipmentObserverHandler->expects($this->once())
+      ->method('execute')
+      ->with(
+        $this->equalTo(['path' => Integration::EXTEND_INTEGRATION_ENDPOINTS['webhooks_shipments_update'], 'type' => 'middleware']),
+        $this->equalTo($this->shipmentMock),
+        $this->equalTo([])
+      );
+    $this->import->execute($this->observer);
+  }
+
+  public function testLogsErrorsToLoggingService()
+  {
+    $this->shipmentObserverHandler->expects($this->once())
+      ->method('execute')
+      ->willThrowException(new Exception());
+    $this->logger->expects($this->once())
+      ->method('error');
+    $this->integration->expects($this->once())
+      ->method('logErrorToLoggingService');
+    $this->import->execute($this->observer);
+  }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -18,6 +18,9 @@
     <event name="sales_order_shipment_track_save_after">
         <observer instance="Extend\Integration\Observer\SalesOrderShipmentTrackSaveAfter" name="extend_sales_order_shipment_track_save_after" />
     </event>
+    <event name="sales_order_shipment_track_delete_after">
+        <observer instance="Extend\Integration\Observer\SalesOrderShipmentTrackDeleteAfter" name="extend_sales_order_shipment_track_delete_after" />
+    </event>
     <event name="controller_action_catalog_product_save_entity_after">
         <observer instance="Extend\Integration\Observer\CatalogProductSaveEntityAfter" name="extend_controller_action_catalog_product_save_entity_after"/>
     </event>


### PR DESCRIPTION
Similar to what we needed to do for adding a track, we also need to observe a track being deleted so the corresponding Extend shipment is properly updated