### PR TITLE
[PAR-3964] Rename Extend to extendSdk to work alongside existing module

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,7 @@
 var config = {
   map: {
     '*': {
-      Extend: 'https://sdk.helloextend.com/extend-sdk-client/v1/extend-sdk-client.min.js',
+      extendSdk: 'https://sdk.helloextend.com/extend-sdk-client/v1/extend-sdk-client.min.js',
       ExtendMagento: 'https://sdk.helloextend.com/extend-sdk-client-magento-addon/v1/extend-sdk-client-magento-addon.min.js'
     }
   }

--- a/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
+++ b/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
@@ -8,7 +8,7 @@ define(
       'uiComponent',
       'ko',
       'Magento_Checkout/js/model/quote',
-      'Extend',
+      'extendSdk',
       'ExtendMagento',
   ],
   function (Component, ko, magentoQuote, Extend, ExtendMagento) {


### PR DESCRIPTION
The [current module](https://github.com/helloextend/magento-extension/blob/c6d4fd2dd274bfcf2c7445bb50af9da082b36ea2/view/frontend/templates/installation.phtml#LL21C22-L21C31) uses `requirejs` to import the SDK under `extendSdk`. When our `requirejs` imports the same script under `Extend`, it is actually already cached so `Extend` is never officially loaded, ultimately causing the `define` in `shipping-protection-offer.js` to never be finished.