### PR TITLE
[PAR-3949] Add parent API resources to fix resources not being rendered in UI

### DIFF
--- a/etc/integration/api.xml
+++ b/etc/integration/api.xml
@@ -7,19 +7,30 @@
 <integrations>
     <integration name="Extend Integration - Production">
         <resources>
+            <resource name="Magento_Backend::admin" />
+            <resource name="Magento_Backend::system" />
+            <resource name="Magento_Backend::stores" />
+            <resource name="Magento_Backend::store" />
             <resource name="Extend_Integration::manage" />
+            <resource name="Magento_Sales::sales" />
+            <resource name="Magento_Sales::sales_operation" />
             <resource name="Magento_Sales::actions_view" />
             <resource name="Magento_Sales::shipment" />
-            <resource name="Magento_Backend::store" />
+            <resource name="Magento_Catalog::catalog" />
             <resource name="Magento_Catalog::products" />
         </resources>
     </integration>
     <integration name="Extend Integration - Demo">
         <resources>
+            <resource name="Magento_Backend::admin" />
+            <resource name="Magento_Backend::system" />
+            <resource name="Magento_Backend::stores" />
+            <resource name="Magento_Backend::store" />
             <resource name="Extend_Integration::manage" />
+            <resource name="Magento_Sales::sales" />
             <resource name="Magento_Sales::actions_view" />
             <resource name="Magento_Sales::shipment" />
-            <resource name="Magento_Backend::store" />
+            <resource name="Magento_Catalog::catalog" />
             <resource name="Magento_Catalog::products" />
         </resources>
     </integration>


### PR DESCRIPTION
If you specify a resource to be used then you must include the parent resource as well. You can see this in the comments in the following [Magento example](https://devdocs.magento.com/guides/v2.3/get-started/create-integration.html#resources).

```
<!-- 
To grant permission to Magento_Log::online, its parent Magento_Customer::customer needs to be declared as well-->
<resource name="Magento_Customer::customer" />
<resource name="Magento_Log::online" />
<!-- To grant permission to Magento_Sales::reorder, all its parent resources need to be declared-->
<resource name="Magento_Sales::sales" />
<resource name="Magento_Sales::sales_operation" />
<resource name="Magento_Sales::sales_order" />
<resource name="Magento_Sales::actions" />
<resource name="Magento_Sales::reorder" />
``` 

In order to get the permissions I did for this PR I took `Magento_Backend::admin` and `Magento_Backend::system` from `acl.xml` as parents of the Extend Integration and the others I got from ChatGPT.

Screenshots of UI after this change:
<img width="674" alt="Screen Shot 2023-04-03 at 11 33 58 PM" src="https://user-images.githubusercontent.com/120399500/229804069-41e90cf9-755b-40b0-9a19-da661eb58c20.png">
<img width="487" alt="Screen Shot 2023-04-04 at 9 18 10 AM" src="https://user-images.githubusercontent.com/120399500/229804482-5aea4bc6-e7da-4734-ac64-a5b865988dd6.png">
