### PR TITLE
[PAR-4015]: Remove client_secret from unique constraint

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -45,7 +45,6 @@
             <column name="store_uuid"/>
             <column name="extend_store_uuid"/>
             <column name="client_id"/>
-            <column name="client_secret"/>
         </constraint>
     </table>
 </schema>


### PR DESCRIPTION
JIRA Ticket: https://helloextend.atlassian.net/browse/PAR-4015

When attempting an install with MySQL we would receive the following error:
```
Syntax error or access violation: 1170 BLOB/TEXT column 'client_secret' used in key specification without a key length
```

The issue is that we're attempting to use a variable length type (TEXT) as part of a unique constraint for our table and MySQL only allows fixed length varchar/char/etc fields to be used this way. We already have `extend_store_uuid`, `store_uuid` and `client_id` as part of the constraint which should be enough to enforce uniqueness. 