### PR TITLE
fix: [PAR-4027] Remove SP on cart page and do not show in order summary

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -6,28 +6,15 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.totals">
-            <arguments>
-                <argument name="jsLayout" xsi:type="array">
-                    <item name="components" xsi:type="array">
-                        <item name="block-totals" xsi:type="array">
-                            <item name="children" xsi:type="array">
-                                <!-- Start of the main content that needs to be added-->
-                                <item name="shipping_protection" xsi:type="array">
-                                    <!-- The path to our js file-->
-                                    <item name="component" xsi:type="string">Extend_Integration/js/view/checkout/summary/shipping-protection</item>
-                                    <item name="sortOrder" xsi:type="string">24</item>
-                                    <item name="config" xsi:type="array">
-                                        <!-- Show custom shipping protection on order summary-->
-                                        <item name="template" xsi:type="string">Extend_Integration/checkout/summary/shipping-protection</item>
-                                        <item name="title" xsi:type="string" translate="true">Shipping Protection</item>
-                                    </item>
-                                </item>
-                                <!--  End-->
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="shipping-protection" xsi:type="array">
+                                <item name="component" xsi:type="string">Extend_Integration/js/view/cart/shipping-protection</item>
                             </item>
                         </item>
-                    </item>
-                </argument>
-            </arguments>
+                    </argument>
+                </arguments>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/web/js/view/cart/shipping-protection.js
+++ b/view/frontend/web/js/view/cart/shipping-protection.js
@@ -1,0 +1,21 @@
+define([
+    'Magento_Checkout/js/model/totals',
+    'ExtendMagento',
+], function (totals, ExtendMagento) {
+    'use strict';
+
+    return function () {
+        try {
+            if (totals.getSegment('shipping_protection')) {
+                ExtendMagento.removeSpPlanFromOrder({
+                    callback: function (_err, _resp) {
+                        // Add custom callback here if needed for integration
+                    },
+                });
+            }
+        } catch (error) {
+            // Swallow error to avoid impacting customer checkout experience
+            console.error(error)
+        }
+    };
+});

--- a/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
+++ b/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
@@ -46,11 +46,11 @@ define(
                                 // make another action that triggers one of these functions the totals() output will be stale which can
                                 // lead to undesirable effects such as SP not staying checked if you uncheck and recheck it
                                 getTotalsAction([])
-                                
+
                                 // Reload is not necessary at the offers current location. SP Totals will show on the next checkout step.
                                 // If the offer is moved anywhere the SP price is showing (Order Summary), a reload is necessary
                                 // window.location.reload();
-                              }               
+                              }
                             })
                         },
                         onDisable: function(){
@@ -80,11 +80,11 @@ define(
                                   // make another action that triggers one of these functions the totals() output will be stale which can
                                   // lead to undesirable effects such as SP not staying checked if you uncheck and recheck it
                                   getTotalsAction([])
-                                  
+
                                   // Reload is not necessary at the offers current location. SP Totals will show on the next checkout step.
                                   // If the offer is moved anywhere the SP price is showing (Order Summary), a reload is necessary
                                   // window.location.reload();
-                                }               
+                                }
                             })
                         }
                     }

--- a/view/frontend/web/js/view/checkout/summary/shipping-protection.js
+++ b/view/frontend/web/js/view/checkout/summary/shipping-protection.js
@@ -23,8 +23,13 @@ define(
             },
             getValue: function() {
                 var price = 0;
-                if (this.totals() && totals.getSegment('shipping_protection')) {
-                    price = totals.getSegment('shipping_protection').value;
+                try {
+                    if (this.totals() && totals.getSegment('shipping_protection')) {
+                        price = totals.getSegment('shipping_protection').value;
+                    }
+                } catch (error) {
+                    // Swallow error to avoid impacting customer checkout experience
+                    console.error(error)
                 }
                 return price;
             }


### PR DESCRIPTION
[PAR-4027](https://helloextend.atlassian.net/browse/PAR-4027)

- Do not show SP in order summary on cart page
- When on cart page, remove SP from order
- Add some try/catch around custom js to avoid impacting customer checkout experience

[PAR-4027]: https://helloextend.atlassian.net/browse/PAR-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ