### PR TITLE
[PAR-4037] Use getTotalsAction for updating totals() output without page refresh

### DIFF
--- a/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
+++ b/view/frontend/web/js/view/checkout/summary/shipping-protection-offer.js
@@ -9,10 +9,11 @@ define(
       'ko',
       'Magento_Customer/js/customer-data',
       'Magento_Checkout/js/model/quote',
+      'Magento_Checkout/js/action/get-totals',
       'extendSdk',
       'ExtendMagento',
   ],
-  function (Component, ko, customerData, magentoQuote, Extend, ExtendMagento) {
+  function (Component, ko, customerData, magentoQuote, getTotalsAction, Extend, ExtendMagento) {
       "use strict";
       return Component.extend({
         defaults: {
@@ -39,6 +40,12 @@ define(
                             if (err) {
                               return;
                             }
+
+                            // getTotalsAction updates the `total_segments` returned in totals(). If this is not run then if you 
+                            // make another action that triggers one of these functions the totals() output will be stale which can
+                            // lead to undesirable effects such as SP not staying checked if you uncheck and recheck it
+                            getTotalsAction([])
+
                             // Reload is not necessary at the offers current location. SP Totals will show on the next checkout step.
                             // If the offer is moved anywhere the SP price is showing (Order Summary), a reload is necessary
                             // window.location.reload();
@@ -51,6 +58,11 @@ define(
                               if (err) {
                                 return;
                               }
+
+                              // getTotalsAction updates the `total_segments` returned in totals(). If this is not run then if you 
+                              // make another action that triggers one of these functions the totals() output will be stale which can
+                              // lead to undesirable effects such as SP not staying checked if you uncheck and recheck it
+                              getTotalsAction([])
                             }
                         })
                     },
@@ -62,6 +74,12 @@ define(
                               if (err) {
                                 return;
                               }
+
+                              // getTotalsAction updates the `total_segments` returned in totals(). If this is not run then if you 
+                              // make another action that triggers one of these functions the totals() output will be stale which can
+                              // lead to undesirable effects such as SP not staying checked if you uncheck and recheck it
+                              getTotalsAction([])
+
                               // Reload is not necessary at the offers current location. SP Totals will show on the next checkout step.
                               // If the offer is moved anywhere the SP price is showing (Order Summary), a reload is necessary
                               // window.location.reload();


### PR DESCRIPTION
Currently there's a bug where if you load a page that had the SP (shipping protection) option checked and a SP total already in the `total_segments` item of the quote then if you unchecked SP there would be no way of getting an re-check to stick unless you totally refreshed the page.

The underlying issue is that unchecking the checkbox removes it from the Magento quote but the `totals()` that pull from that quote in JavaScript were not refreshed until page reload so when you went to opt into SP again it would pass a `total_segments` array that already contained a 'shipping_protection' segment that had been removed. This would fail upstream where we'd check for the existing of that item and if we found it we would simply stop the add SP item process.