### PR TITLE
[PAR-4078] Magento integration store undefined

### DIFF
--- a/Model/StoreIntegrationRepository.php
+++ b/Model/StoreIntegrationRepository.php
@@ -99,10 +99,15 @@ class StoreIntegrationRepository implements \Extend\Integration\Api\StoreIntegra
     public function getByStoreIdAndIntegrationId(int $storeId, int $integrationId): StoreIntegrationInterface
     {
         $storeIntegrationCollection = $this->storeIntegrationCollectionFactory->create();
-        return $storeIntegrationCollection
+        $storeIntegration = $storeIntegrationCollection
             ->addFieldToFilter('store_id', ['eq' => $storeId])
             ->addFieldToFilter('integration_id', ['eq' => $integrationId])
             ->getFirstItem();
+        if ($storeIntegration->getId()) {
+            return $storeIntegration;
+        } else {
+            throw new NoSuchEntityException(__('Integration not found'));
+        }
     }
 
     /**


### PR DESCRIPTION
- Add check for empty result to `getByStoreIdAndIntegrationId` before returning value and throw error if no integration found for the given `storeId`

https://helloextend.atlassian.net/browse/PAR-4078