### PR TITLE
bugfix: [PAR-4224] fix bash script error where multiple files can not be linted

### DIFF
--- a/scripts/lint-and-display-diff.sh
+++ b/scripts/lint-and-display-diff.sh
@@ -12,7 +12,7 @@ fi
 files=$(git diff --diff-filter=ACMRTUXB --name-only origin/master)
 
 # Filter the list of files to include only files with file extension $1
-matched_files=$(echo "$files" | grep -E "(.$1$)")
+matched_files=$(echo "$files" | grep -E "(.$1$)" | tr '\n' ' ')
 
 # If there are no files with extension $1, exit with a status code of 0
 if [ -z "$matched_files" ]; then
@@ -46,8 +46,8 @@ fi
 # This runs prettier (altering the files), runs a git diff against origin/master,
 # and then restores the files to their original state.
 eval "$prettier_command --write --loglevel silent $matched_files"
-git --no-pager diff origin/master $matched_files
-git -C $(git rev-parse --show-toplevel) restore .
+eval "git --no-pager diff origin/master $matched_files"
+git -C "$(git rev-parse --show-toplevel)" restore .
 
 echo -e "\n"
 echo -e "These ^ files will be auto-formatted upon commit... or you can:"


### PR DESCRIPTION
# Description

* `matched_files` in the old script contained newlines (each file that `grep` matched got its own line). removed those and the git + prettier commands are no longer angry

## Ticket

https://helloextend.atlassian.net/browse/PAR-4224

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
