### PR TITLE
chore: [PAR-4223] move prettier config into package.json so that phpstorm can recognize it

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 100,
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "arrowParens": "avoid"
-}

--- a/.prettierrc.xml.json
+++ b/.prettierrc.xml.json
@@ -1,5 +1,0 @@
-{
-  "printWidth": 1000,
-  "xmlWhitespaceSensitivity": "ignore",
-  "xmlSelfClosingSpace": true
-}

--- a/package.json
+++ b/package.json
@@ -21,11 +21,8 @@
     "*.{ts,js}": [
       "eslint --fix"
     ],
-    "*.{php,html}": [
+    "*.{php,html,xml}": [
       "prettier --write"
-    ],
-    "*.xml": [
-      "prettier --config .prettierrc.xml.json --write"
     ]
   },
   "devDependencies": {
@@ -41,5 +38,22 @@
     "jest": "^29.5.0",
     "lint-staged": "^13.2.2",
     "prettier": "^2.8.8"
+  },
+  "prettier": {
+    "printWidth": 100,
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "arrowParens": "avoid",
+    "overrides": [
+      {
+        "files": "*.xml",
+        "options": {
+          "printWidth": 1000,
+          "xmlWhitespaceSensitivity": "ignore",
+          "xmlSelfClosingSpace": true
+        }
+      }
+    ]
   }
 }

--- a/scripts/lint-and-display-diff.sh
+++ b/scripts/lint-and-display-diff.sh
@@ -27,11 +27,7 @@ if ! git diff --quiet; then
 fi
 
 # Set the prettier command to a variable, based on file extension
-if [ "$1" == "xml" ]; then
-  prettier_command="yarn prettier --parser=$1 --config .prettierrc.xml.json"
-else
-  prettier_command="yarn prettier --parser=$1"
-fi
+prettier_command="yarn prettier --parser=$1"
 
 # Check the formatting of the files
 eval "$prettier_command --check $matched_files"


### PR DESCRIPTION
# Description

* PHPStorm needs prettier config to live in `package.json` for it to be recognized by the IDE (in this case the config is used for setting custom rules for XML). This isn't a bad practice anyway!
* With this implemented and a few manual steps taken in PHPStorm, the IDE will lint and auto-format .php, .js, and .xml files according to our eslint/prettier config.

## Ticket

https://helloextend.atlassian.net/browse/PAR-4223

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
