### PR TITLE
[PAR-4286] Add DI Preference for ShippingProtection

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,53 +1,45 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <!--
   ~ Copyright Extend (c) 2022. All rights reserved.
   ~ See Extend-COPYING.txt for license details.
   -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Extend\Integration\Api\Data\ShippingProtectionInterface" type="Extend\Integration\Model\ShippingProtection"/>
-    <preference for="Extend\Integration\Api\ShippingProtectionTotalRepositoryInterface" type="Extend\Integration\Model\ShippingProtectionTotalRepository"/>
-    <preference for="Extend\Integration\Api\ProductProtectionInterface" type="Extend\Integration\Model\ProductProtection"/>
-    <preference for="Extend\Integration\Api\StoreIntegrationRepositoryInterface" type="Extend\Integration\Model\StoreIntegrationRepository"/>
-    <type name="Magento\Sales\Model\OrderRepository">
-        <plugin sortOrder="1" name="extendIntegrationOrderRepository"
-                type="Extend\Integration\Plugin\Model\OrderRepositoryPlugin"/>
-    </type>
-    <type name="Magento\Sales\Model\Order\InvoiceRepository">
-        <plugin sortOrder="1" name="extendIntegrationInvoiceRepository"
-                type="Extend\Integration\Plugin\Model\Order\InvoiceRepositoryPlugin"/>
-    </type>
-    <type name="Magento\Sales\Model\Convert\Order">
-        <plugin sortOrder="1" name="extendIntegrationOrder" type="Extend\Integration\Plugin\Model\Convert\OrderPlugin"/>
-    </type>
-    <type name="Magento\Quote\Model\QuoteRepository">
-        <plugin sortOrder="1" name="extendIntegrationQuoteRepository"
-                type="Extend\Integration\Plugin\Model\QuoteRepositoryPlugin"/>
-    </type>
-    <type name="Magento\Integration\Controller\Adminhtml\Integration\Save">
-        <plugin sortOrder="1" name="extendIntegrationSave"
-                type="Extend\Integration\Plugin\Controller\Adminhtml\Integration\SavePlugin"/>
-    </type>
-    <type name="Magento\Quote\Model\Cart\TotalsConverter">
-        <plugin sortOrder="1" name="extendIntegrationTotalsConverter"
-                type="Extend\Integration\Plugin\Model\Cart\TotalsConverterPlugin"/>
-    </type>
-    <type name="Magento\Sales\Controller\AbstractController\OrderLoader">
-        <plugin sortOrder="1" name="extendIntegrationOrderLoader"
-                type="Extend\Integration\Plugin\Controller\AbstractController\OrderLoaderPlugin"/>
-    </type>
-    <type name="Magento\Sales\Controller\Adminhtml\Order\Invoice\Save">
-        <plugin sortOrder="1" name="extendIntegrationSave"
-                type="Extend\Integration\Plugin\Controller\Adminhtml\Order\Invoice\SavePlugin"/>
-    </type>
-    <type name="Magento\Sales\Model\Order\CreditmemoRepository">
-        <plugin sortOrder="1" name="extendIntegrationCreditmemoRepository"
-                type="Extend\Integration\Plugin\Model\Order\CreditmemoRepositoryPlugin"/>
-    </type>
-    <type name="Magento\Catalog\Model\ProductRepository">
-        <plugin name="extendProductExtensionAttributes" type="Extend\Integration\Plugin\Catalog\Model\ProductRepositoryPlugin"/>
-    </type>
-    <preference for="Magento\Framework\HTTP\ZendClient" type="Extend\Integration\Preference\Framework\Http\ZendClientPreference"/>
-    <type name="Magento\Sales\Model\Order">
-        <plugin sortOrder="1" name="extendIntegrationOrder" type="Extend\Integration\Plugin\Model\OrderPlugin"/>
-    </type>
+  <preference for="Extend\Integration\Api\Data\ShippingProtectionInterface" type="Extend\Integration\Model\ShippingProtection" />
+  <preference for="Extend\Integration\Api\ShippingProtectionTotalRepositoryInterface" type="Extend\Integration\Model\ShippingProtectionTotalRepository" />
+  <preference for="Extend\Integration\Api\ProductProtectionInterface" type="Extend\Integration\Model\ProductProtection" />
+  <preference for="Extend\Integration\Api\StoreIntegrationRepositoryInterface" type="Extend\Integration\Model\StoreIntegrationRepository" />
+  <type name="Magento\Sales\Model\OrderRepository">
+    <plugin sortOrder="1" name="extendIntegrationOrderRepository" type="Extend\Integration\Plugin\Model\OrderRepositoryPlugin" />
+  </type>
+  <type name="Magento\Sales\Model\Order\InvoiceRepository">
+    <plugin sortOrder="1" name="extendIntegrationInvoiceRepository" type="Extend\Integration\Plugin\Model\Order\InvoiceRepositoryPlugin" />
+  </type>
+  <type name="Magento\Sales\Model\Convert\Order">
+    <plugin sortOrder="1" name="extendIntegrationOrder" type="Extend\Integration\Plugin\Model\Convert\OrderPlugin" />
+  </type>
+  <type name="Magento\Quote\Model\QuoteRepository">
+    <plugin sortOrder="1" name="extendIntegrationQuoteRepository" type="Extend\Integration\Plugin\Model\QuoteRepositoryPlugin" />
+  </type>
+  <type name="Magento\Integration\Controller\Adminhtml\Integration\Save">
+    <plugin sortOrder="1" name="extendIntegrationSave" type="Extend\Integration\Plugin\Controller\Adminhtml\Integration\SavePlugin" />
+  </type>
+  <type name="Magento\Quote\Model\Cart\TotalsConverter">
+    <plugin sortOrder="1" name="extendIntegrationTotalsConverter" type="Extend\Integration\Plugin\Model\Cart\TotalsConverterPlugin" />
+  </type>
+  <type name="Magento\Sales\Controller\AbstractController\OrderLoader">
+    <plugin sortOrder="1" name="extendIntegrationOrderLoader" type="Extend\Integration\Plugin\Controller\AbstractController\OrderLoaderPlugin" />
+  </type>
+  <type name="Magento\Sales\Controller\Adminhtml\Order\Invoice\Save">
+    <plugin sortOrder="1" name="extendIntegrationSave" type="Extend\Integration\Plugin\Controller\Adminhtml\Order\Invoice\SavePlugin" />
+  </type>
+  <type name="Magento\Sales\Model\Order\CreditmemoRepository">
+    <plugin sortOrder="1" name="extendIntegrationCreditmemoRepository" type="Extend\Integration\Plugin\Model\Order\CreditmemoRepositoryPlugin" />
+  </type>
+  <type name="Magento\Catalog\Model\ProductRepository">
+    <plugin name="extendProductExtensionAttributes" type="Extend\Integration\Plugin\Catalog\Model\ProductRepositoryPlugin" />
+  </type>
+  <preference for="Magento\Framework\HTTP\ZendClient" type="Extend\Integration\Preference\Framework\Http\ZendClientPreference" />
+  <type name="Magento\Sales\Model\Order">
+    <plugin sortOrder="1" name="extendIntegrationOrder" type="Extend\Integration\Plugin\Model\OrderPlugin" />
+  </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,6 +4,7 @@
   ~ See Extend-COPYING.txt for license details.
   -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Extend\Integration\Api\Data\ShippingProtectionInterface" type="Extend\Integration\Model\ShippingProtection"/>
     <preference for="Extend\Integration\Api\ShippingProtectionTotalRepositoryInterface" type="Extend\Integration\Model\ShippingProtectionTotalRepository"/>
     <preference for="Extend\Integration\Api\ProductProtectionInterface" type="Extend\Integration\Model\ProductProtection"/>
     <preference for="Extend\Integration\Api\StoreIntegrationRepositoryInterface" type="Extend\Integration\Model\StoreIntegrationRepository"/>


### PR DESCRIPTION
# Description

- Add a preference for the `ShippingProtectionInterface` for the `ShippingProtection` type for dependency injections (`di.xml`) since I was running into the following when trying to create a Credit Memo Refund via API:
```
Body: Error: Cannot instantiate interface Extend\Integration\Api\Data\ShippingProtectionInterface in /chroot/home/aeb3d7e2/b336295cb8.nxcli.io/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php:50
```

## Ticket

https://helloextend.atlassian.net/browse/PAR-4286

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
