### PR TITLE
[PAR-4469] handle authorize and capture auto invoicing

### DIFF
--- a/Model/Sales/Order/Invoice/Total/ShippingProtection.php
+++ b/Model/Sales/Order/Invoice/Total/ShippingProtection.php
@@ -42,30 +42,71 @@ class ShippingProtection extends \Magento\Sales\Model\Order\Invoice\Total\Abstra
      */
     public function collect(Invoice $invoice): ShippingProtection
     {
-
-        if ($shippingProtection = $invoice->getExtensionAttributes()->getShippingProtection()) {
-            foreach ($invoice->getOrder()->getInvoiceCollection()->getAllIds() as $invoiceId) {
-                if ($this->shippingProtectionTotalRepository->get($invoiceId, ShippingProtectionTotalInterface::INVOICE_ENTITY_TYPE_ID) && $this->shippingProtectionTotalRepository->get($invoiceId, ShippingProtectionTotalInterface::INVOICE_ENTITY_TYPE_ID)->getShippingProtectionBasePrice() > 0) {
+        if (
+            $shippingProtection =
+                $invoice->getExtensionAttributes()->getShippingProtection() &&
+                $invoice->getOrderId()
+        ) {
+            foreach (
+                $invoice
+                    ->getOrder()
+                    ->getInvoiceCollection()
+                    ->getAllIds()
+                as $invoiceId
+            ) {
+                if (
+                    $this->shippingProtectionTotalRepository->get(
+                        $invoiceId,
+                        ShippingProtectionTotalInterface::INVOICE_ENTITY_TYPE_ID
+                    ) &&
+                    $this->shippingProtectionTotalRepository
+                        ->get($invoiceId, ShippingProtectionTotalInterface::INVOICE_ENTITY_TYPE_ID)
+                        ->getShippingProtectionBasePrice() > 0
+                ) {
                     $this->zeroOutShippingProtection($invoice, $shippingProtection);
                     return $this;
                 }
             }
 
             foreach ($invoice->getAllItems() as $item) {
-                if ((int)$item->getQty() > 0 && $item->getOrderItem()->getIsVirtual() == "0") {
+                if ((int) $item->getQty() > 0 && $item->getOrderItem()->getIsVirtual() == '0') {
                     $shippingProtectionBasePrice = $shippingProtection->getBase();
                     $shippingProtectionPrice = $shippingProtection->getPrice();
 
                     $invoice->setBaseShippingProtection($shippingProtectionBasePrice);
                     $invoice->setShippingProtection($shippingProtectionPrice);
 
-                    $invoice->setGrandTotal($invoice->getGrandTotal() + $invoice->getShippingProtection());
-                    $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $invoice->getBaseShippingProtection());
+                    $invoice->setGrandTotal(
+                        $invoice->getGrandTotal() + $invoice->getShippingProtection()
+                    );
+                    $invoice->setBaseGrandTotal(
+                        $invoice->getBaseGrandTotal() + $invoice->getBaseShippingProtection()
+                    );
                     return $this;
                 }
             }
 
             $this->zeroOutShippingProtection($invoice, $shippingProtection);
+        } elseif (
+            $shippingProtection = $invoice->getExtensionAttributes()->getShippingProtection()
+        ) {
+            foreach ($invoice->getAllItems() as $item) {
+                if ($item->getOrderItem()->getIsVirtual() == '0') {
+                    $shippingProtectionBasePrice = $shippingProtection->getBase();
+                    $shippingProtectionPrice = $shippingProtection->getPrice();
+
+                    $invoice->setBaseShippingProtection($shippingProtectionBasePrice);
+                    $invoice->setShippingProtection($shippingProtectionPrice);
+
+                    $invoice->setGrandTotal(
+                        $invoice->getGrandTotal() + $invoice->getShippingProtection()
+                    );
+                    $invoice->setBaseGrandTotal(
+                        $invoice->getBaseGrandTotal() + $invoice->getBaseShippingProtection()
+                    );
+                    return $this;
+                }
+            }
         }
 
         return $this;
@@ -81,18 +122,22 @@ class ShippingProtection extends \Magento\Sales\Model\Order\Invoice\Total\Abstra
      * @param ShippingProtectionInterface $shippingProtection
      * @return void
      */
-    private function zeroOutShippingProtection(Invoice $invoice, \Extend\Integration\Api\Data\ShippingProtectionInterface $shippingProtectionTotal)
-    {
-        $invoice->setBaseShippingProtection(0.00);
-        $invoice->setShippingProtection(0.00);
+    private function zeroOutShippingProtection(
+        Invoice $invoice,
+        \Extend\Integration\Api\Data\ShippingProtectionInterface $shippingProtectionTotal
+    ) {
+        $invoice->setBaseShippingProtection(0.0);
+        $invoice->setShippingProtection(0.0);
 
         $invoice->setGrandTotal($invoice->getGrandTotal() + $invoice->getShippingProtection());
-        $invoice->setBaseGrandTotal($invoice->getBaseGrandTotal() + $invoice->getBaseShippingProtection());
+        $invoice->setBaseGrandTotal(
+            $invoice->getBaseGrandTotal() + $invoice->getBaseShippingProtection()
+        );
 
         $shippingProtection = $this->shippingProtectionFactory->create();
-        $shippingProtection->setBase(0.00);
+        $shippingProtection->setBase(0.0);
         $shippingProtection->setBaseCurrency($shippingProtectionTotal->getBaseCurrency());
-        $shippingProtection->setPrice(0.00);
+        $shippingProtection->setPrice(0.0);
         $shippingProtection->setCurrency($shippingProtectionTotal->getCurrency());
         $shippingProtection->setSpQuoteId($shippingProtectionTotal->getSpQuoteId());
         $extensionAttributes = $invoice->getExtensionAttributes();

--- a/Observer/InvoiceSaveAfter.php
+++ b/Observer/InvoiceSaveAfter.php
@@ -11,7 +11,6 @@ use Extend\Integration\Service\Api\Integration;
 use Extend\Integration\Service\Api\OrderObserverHandler;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\StoreManagerInterface;
-//JM
 use Extend\Integration\Api\ShippingProtectionTotalRepositoryInterface;
 use Magento\Sales\Api\Data\InvoiceExtensionFactory;
 


### PR DESCRIPTION
# Description

This saves the EA values from the invoice object to the extend table by adding a transfer point in the invoice observer which already exist.  This is necessary because authorize and capture auto creates the invoice and doesn't use the invoice respository.  This also adjusts the invoice collectTotals methods to handle orders and invoices that haven't been given ids yet, because they haven't been committed to the db yet.

## Ticket

PAR-4469

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works