### PR TITLE
[PAR-4464] magento additional offer requests made during add to cart event

### DIFF
--- a/ViewModel/CategoriesForMinicartProducts.php
+++ b/ViewModel/CategoriesForMinicartProducts.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright Extend (c) 2023. All rights reserved.
+ * See Extend-COPYING.txt for license details.
+ */
+
+namespace Extend\Integration\ViewModel;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Checkout\Model\Session;
+
+class CategoriesForMinicartProducts implements
+    \Magento\Framework\View\Element\Block\ArgumentInterface
+{
+    private Session $cartSession;
+    private CategoryRepositoryInterface $categoryRepository;
+
+    public function __construct(
+        Session $cartSession,
+        CategoryRepositoryInterface $categoryRepository
+    ) {
+        $this->cartSession = $cartSession;
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    public function getProductCategories()
+    {
+        $products = [];
+        $quote = $this->cartSession->getQuote();
+        foreach ($quote->getAllVisibleItems() as $item) {
+            $product = $item->getProduct();
+            if ($product->getCategoryIds()) {
+                $categoryAssoc = [];
+                foreach ($product->getCategoryIds() as $categoryId) {
+                    $category = $this->categoryRepository->get($categoryId);
+                    $categoryAssoc[] = $category->getName();
+                }
+                $products[$product->getSku()]['categories'] = $categoryAssoc;
+            }
+        }
+        return $products;
+    }
+}

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -9,6 +9,7 @@
             <block name="extend.minicart" ifconfig="extend/product_protection/enable" template="Extend_Integration::cart/minicart-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
+                    <argument name="categoriesForMinicartProducts" xsi:type="object">Extend\Integration\ViewModel\CategoriesForMinicartProducts</argument>
                 </arguments>
             </block>
             <block name="extend.aftermarket-product-protection-modal-offer" ifconfig="extend/product_protection/enable" template="Extend_Integration::catalog/product/view/aftermarket-product-protection-modal-offer.phtml">

--- a/view/frontend/templates/cart/minicart-simple-offer.phtml
+++ b/view/frontend/templates/cart/minicart-simple-offer.phtml
@@ -6,6 +6,8 @@
 $viewModel = $block->getData('viewModel');
 $extendStoreUuid = $viewModel->getExtendStoreUuid();
 $activeEnvironment = $viewModel->getActiveEnvironment();
+$categoriesForMinicartProducts = $block->getData('categoriesForMinicartProducts');
+$productsCategories = $categoriesForMinicartProducts->getProductCategories();
 ?>
 
 <div id="extendMinicartSimpleOffer"></div>
@@ -15,7 +17,8 @@ $activeEnvironment = $viewModel->getActiveEnvironment();
             "minicartSimpleOffer": [
                {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
-                    "activeEnvironment": "<?= $activeEnvironment ?>"
+                    "activeEnvironment": "<?= $activeEnvironment ?>",
+                    "productsCategories": <?= json_encode($productsCategories) ?>
                 }
             ]
         }

--- a/view/frontend/web/js/utils/cart-utils.js
+++ b/view/frontend/web/js/utils/cart-utils.js
@@ -6,7 +6,7 @@ define(['Magento_Customer/js/customer-data'], function (customerData) {
   'use strict'
 
   const getCartItems = function () {
-    return customerData.get('cart')().items
+    return customerData.get('cart')().items ?? []
   }
 
   const refreshMiniCart = function () {

--- a/view/frontend/web/js/view/cart/minicart-updates.js
+++ b/view/frontend/web/js/view/cart/minicart-updates.js
@@ -41,7 +41,6 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
               Extend.buttons.renderSimpleOffer(`#${simpleOfferElemId}`, {
                 referenceId: cartItem.product_sku,
                 price: cartItem.product_price_value * 100,
-                category: cartItem.product_category,
                 onAddToCart: function (opts) {
                   addToCart(opts)
                 },

--- a/view/frontend/web/js/view/cart/minicart-updates.js
+++ b/view/frontend/web/js/view/cart/minicart-updates.js
@@ -14,7 +14,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
   const itemDetailsSelector = 'div.product-item-details'
   const simpleOfferClass = 'extend-minicart-simple-offer'
 
-  const handleUpdate = function () {
+  const handleUpdate = function (config) {
     const cartItems = cartUtils.getCartItems()
 
     cartItems.forEach(cartItem => {
@@ -95,6 +95,6 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     }
     Extend.config(extendConfig)
 
-    $(minicartSelector).on('contentUpdated', handleUpdate)
+    $(minicartSelector).on('contentUpdated', () => handleUpdate(config))
   }
 })

--- a/view/frontend/web/js/view/cart/minicart-updates.js
+++ b/view/frontend/web/js/view/cart/minicart-updates.js
@@ -18,10 +18,10 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     const cartItems = cartUtils.getCartItems()
 
     cartItems.forEach(cartItem => {
+      if (cartItem.product_sku === 'extend-protection-plan') return
       const qtyElem = document.getElementById(`cart-item-${cartItem.item_id}-qty`)
       if (qtyElem) {
         const itemContainerElem = qtyElem.closest(productItemSelector)
-
         if (itemContainerElem) {
           const simpleOfferElemId = `extend-minicart-simple-offer-${cartItem.item_id}`
           let simpleOfferElem = itemContainerElem.querySelector(`#${simpleOfferElemId}`)
@@ -41,6 +41,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
               Extend.buttons.renderSimpleOffer(`#${simpleOfferElemId}`, {
                 referenceId: cartItem.product_sku,
                 price: cartItem.product_price_value * 100,
+                category: cartItem.product_category,
                 onAddToCart: function (opts) {
                   addToCart(opts)
                 },

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -44,14 +44,14 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
 
   return function (config) {
     const sku = config[0].selectedProductSku
+    if (sku === 'extend-protection-plan') return
+
     const activeProductData = {
       referenceId: config[0].selectedProductSku,
       price: config[0].selectedProductPrice * 100,
-      category: config[0].productCategory,
       onAddToCart: handleAddToCartClick,
     }
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
-    if (sku === 'extend-protection-plan') return
 
     Extend.buttons.renderSimpleOffer(
       '#product_protection_offer_' + config[0].selectedProductSku,

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -43,6 +43,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
   }
 
   return function (config) {
+    const sku = config[0].selectedProductSku
     const activeProductData = {
       referenceId: config[0].selectedProductSku,
       price: config[0].selectedProductPrice * 100,
@@ -50,6 +51,8 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
       onAddToCart: handleAddToCartClick,
     }
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
+    if (sku === 'extend-protection-plan') return
+
     Extend.buttons.renderSimpleOffer(
       '#product_protection_offer_' + config[0].selectedProductSku,
       activeProductData,

--- a/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
@@ -6,11 +6,10 @@
 define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend, ExtendMagento) {
   'use strict'
 
-  const handleAddToCartClick = function (productSku, productPrice, productCategory) {
+  const handleAddToCartClick = function (productSku, productPrice) {
     Extend.modal.open({
       referenceId: productSku,
       price: productPrice,
-      category: productCategory,
       onClose: function (plan, product) {
         if (plan && product) {
           const { planId, price, term, title, coverageType, offerId } = plan
@@ -53,7 +52,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
 
     if (addToCartButton) {
       const handler = function () {
-        handleAddToCartClick(productSku, productPrice, productCategory)
+        handleAddToCartClick(productSku, productPrice)
       }
 
       addToCartButton.addEventListener('click', handler)

--- a/view/frontend/web/js/view/catalog/product/product-protection-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-offer.js
@@ -58,7 +58,6 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
       Extend.buttons.render('#product_protection_offer_' + config[key].selectedProductSku, {
         referenceId: config[key].selectedProductSku,
         price: config[key].selectedProductPrice * 100,
-        category: config[key].productCategory,
       })
     }
 
@@ -71,7 +70,6 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
       const activeProductData = {
         referenceId: selectedProduct.selectedProductSku,
         price: selectedProduct.selectedPrice * 100,
-        category: config.productCategory,
       }
       if (buttonInstance) {
         buttonInstance.setActiveProduct(activeProductData)
@@ -129,8 +127,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
           } else {
             Extend.modal.open({
               referenceId: selectedProduct.selectedProductSku,
-              price: selectedProduct.selectedPrice * 100,
-              category: config.productCategory,
+              price: selectedProduct.selectedProductPrice * 100,
               onClose: function (plan, product) {
                 if (plan && product) {
                   const { planId, price, term, title, coverageType, offerId } = plan


### PR DESCRIPTION
# Description

This PR will address two bugs it is added in the tickets section. We were making additional offers call due to
1. Offers call was made for Extend PP LineItem in Cart. 
2. In minitcart js file Category is not available hence we decided not to send category for any offer surface. 


## Ticket
1. https://helloextend.atlassian.net/browse/PAR-4464
4. https://helloextend.atlassian.net/browse/PAR-4465

List your ticket here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
