### PR TITLE
bugfix: [PAR-4493] fix bug where sp is errrantly set as a bool rather than as ShippingProtection

### DIFF
--- a/Model/Sales/Order/Invoice/Total/ShippingProtection.php
+++ b/Model/Sales/Order/Invoice/Total/ShippingProtection.php
@@ -43,9 +43,8 @@ class ShippingProtection extends \Magento\Sales\Model\Order\Invoice\Total\Abstra
     public function collect(Invoice $invoice): ShippingProtection
     {
         if (
-            $shippingProtection =
-                $invoice->getExtensionAttributes()->getShippingProtection() &&
-                $invoice->getOrderId()
+            ($shippingProtection = $invoice->getExtensionAttributes()->getShippingProtection()) &&
+            $invoice->getOrderId()
         ) {
             foreach (
                 $invoice


### PR DESCRIPTION
# Description

* i tried to invoice an order that had been created for a merchant item with SP (no PP in the order) and saw an error in the logs and a stacktrace indicating that `getBase()` was being called on a boolean.
* this fixes that by adding parentheses around the first of the two conditions in the `if` block in question, ensuring that `$shippingProtection` is actualy set as `ShippingProtection` and not `true`
* verified in xdebug that before the fix, `$shippingProtection` was `true` and after the fix `$shippingProtection` was `Extend\Integration\Model\ShippingProtection`

## Ticket

https://helloextend.atlassian.net/browse/PAR-4493

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
