### PR TITLE
[PAR-4454] element id whitespace sku bug

### DIFF
--- a/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
@@ -6,9 +6,9 @@ $activeEnvironment = $viewModel->getActiveEnvironment();
 
 /** @var \Magento\Catalog\Model\Product $product */
 $product = $block->getProduct();
-
+$productSku = $product->getSku();
 /** encoding to prevent whitespace and other abnormal characters from being used in a div id */
-$encodedProductSku = rawurlencode($product->getSku());
+$encodedProductSku = rawurlencode($productSku);
 $productPrice = $product->getPrice();
 
 $categoryName = '';
@@ -26,7 +26,7 @@ if ($category = $product->getCategory()) {
                 {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>",
-                    "productSku": "<?= $product->getSku() ?>",
+                    "productSku": "<?= $productSku ?>",
                     "productPrice": "<?= $productPrice ?>",
                     "productCategory": "<?= $categoryName ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
@@ -7,8 +7,8 @@ $activeEnvironment = $viewModel->getActiveEnvironment();
 /** @var \Magento\Catalog\Model\Product $product */
 $product = $block->getProduct();
 
-/** replace whitespace as being used as a div id */
-$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
+/** encoding to prevent whitespace and other abnormal characters from being used in a div id */
+$encodedProductSku = urlencode($product->getSku());
 $productPrice = $product->getPrice();
 
 $categoryName = '';
@@ -17,16 +17,16 @@ if ($category = $product->getCategory()) {
 }
 ?>
 
-<div class="product_protection_modal_offer" id="product_protection_modal_offer_<?= $normalizedProductSku ?>"></div>
+<div class="product_protection_modal_offer" id="product_protection_modal_offer_<?= $encodedProductSku ?>"></div>
 
 <script type="text/x-magento-init">
     {
-        "#product_protection_modal_offer_<?= $normalizedProductSku ?>": {
+        "#product_protection_modal_offer_<?= $encodedProductSku ?>": {
             "productProtectionModalOffer": [
                 {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>",
-                    "productSku": "<?= $normalizedProductSku ?>",
+                    "productSku": "<?= $encodedProductSku ?>",
                     "productPrice": "<?= $productPrice ?>",
                     "productCategory": "<?= $categoryName ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
@@ -7,7 +7,8 @@ $activeEnvironment = $viewModel->getActiveEnvironment();
 /** @var \Magento\Catalog\Model\Product $product */
 $product = $block->getProduct();
 
-$productSku = $product->getSku();
+/** replace whitespace as being used as a div id */
+$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
 $productPrice = $product->getPrice();
 
 $categoryName = '';
@@ -16,16 +17,16 @@ if ($category = $product->getCategory()) {
 }
 ?>
 
-<div class="product_protection_modal_offer" id="product_protection_modal_offer_<?= $productSku ?>"></div>
+<div class="product_protection_modal_offer" id="product_protection_modal_offer_<?= $normalizedProductSku ?>"></div>
 
 <script type="text/x-magento-init">
     {
-        "#product_protection_modal_offer_<?= $productSku ?>": {
+        "#product_protection_modal_offer_<?= $normalizedProductSku ?>": {
             "productProtectionModalOffer": [
                 {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>",
-                    "productSku": "<?= $productSku ?>",
+                    "productSku": "<?= $normalizedProductSku ?>",
                     "productPrice": "<?= $productPrice ?>",
                     "productCategory": "<?= $categoryName ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-modal-offer.phtml
@@ -8,7 +8,7 @@ $activeEnvironment = $viewModel->getActiveEnvironment();
 $product = $block->getProduct();
 
 /** encoding to prevent whitespace and other abnormal characters from being used in a div id */
-$encodedProductSku = urlencode($product->getSku());
+$encodedProductSku = rawurlencode($product->getSku());
 $productPrice = $product->getPrice();
 
 $categoryName = '';
@@ -26,7 +26,7 @@ if ($category = $product->getCategory()) {
                 {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>",
-                    "productSku": "<?= $encodedProductSku ?>",
+                    "productSku": "<?= $product->getSku() ?>",
                     "productPrice": "<?= $productPrice ?>",
                     "productCategory": "<?= $categoryName ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
@@ -7,8 +7,6 @@
 /** @var $block \Magento\Catalog\Block\Product\View */
 
 $categoryName = '';
-/** encoding to prevent whitespace and other abnormal characters from being used in a div id */
-$encodedProductSku = urlencode($product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -16,15 +14,15 @@ if ($category = $block->getProduct()->getCategory()) {
 
 ?>
 
-<div class="product-protection-offer" id="product_protection_offer_<?= $encodedProductSku; ?>"></div>
+<div class="product-protection-offer" id="product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()) ?>"></div>
 <script type="text/x-magento-init">
     {
-        "#product_protection_offer_<?= $encodedProductSku; ?>": {
+        "#product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()); ?>": {
             "productProtectionOffer": [
                 {
                     "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                     "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                    "selectedProductSku": "<?= $encodedProductSku; ?>",
+                    "selectedProductSku": "<?= $block->getProduct()->getSku(); ?>",
                     "selectedProductPrice": "<?= $block->getProduct()->getPrice(); ?>",
                     "productCategory": "<?= $categoryName; ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
@@ -7,8 +7,8 @@
 /** @var $block \Magento\Catalog\Block\Product\View */
 
 $categoryName = '';
-/** replace whitespace as being used as a div id */
-$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
+/** encoding to prevent whitespace and other abnormal characters from being used in a div id */
+$encodedProductSku = urlencode($product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -16,15 +16,15 @@ if ($category = $block->getProduct()->getCategory()) {
 
 ?>
 
-<div class="product-protection-offer" id="product_protection_offer_<?= $normalizedProductSku; ?>"></div>
+<div class="product-protection-offer" id="product_protection_offer_<?= $encodedProductSku; ?>"></div>
 <script type="text/x-magento-init">
     {
-        "#product_protection_offer_<?= $normalizedProductSku; ?>": {
+        "#product_protection_offer_<?= $encodedProductSku; ?>": {
             "productProtectionOffer": [
                 {
                     "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                     "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                    "selectedProductSku": "<?= $normalizedProductSku; ?>",
+                    "selectedProductSku": "<?= $encodedProductSku; ?>",
                     "selectedProductPrice": "<?= $block->getProduct()->getPrice(); ?>",
                     "productCategory": "<?= $categoryName; ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
@@ -7,6 +7,8 @@
 /** @var $block \Magento\Catalog\Block\Product\View */
 
 $categoryName = '';
+/** replace whitespace as being used as a div id */
+$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -14,15 +16,15 @@ if ($category = $block->getProduct()->getCategory()) {
 
 ?>
 
-<div class="product-protection-offer" id="product_protection_offer_<?= $block->getProduct()->getSku(); ?>"></div>
+<div class="product-protection-offer" id="product_protection_offer_<?= $normalizedProductSku; ?>"></div>
 <script type="text/x-magento-init">
     {
-        "#product_protection_offer_<?= $block->getProduct()->getSku(); ?>": {
+        "#product_protection_offer_<?= $normalizedProductSku; ?>": {
             "productProtectionOffer": [
                 {
                     "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                     "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                    "selectedProductSku": "<?= $block->getProduct()->getSku(); ?>",
+                    "selectedProductSku": "<?= $normalizedProductSku; ?>",
                     "selectedProductPrice": "<?= $block->getProduct()->getPrice(); ?>",
                     "productCategory": "<?= $categoryName; ?>"
                 }

--- a/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/product-protection-offer.phtml
@@ -14,7 +14,7 @@ if ($category = $block->getProduct()->getCategory()) {
 
 ?>
 
-<div class="product-protection-offer" id="product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()) ?>"></div>
+<div class="product-protection-offer" id="product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()); ?>"></div>
 <script type="text/x-magento-init">
     {
         "#product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()); ?>": {

--- a/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
@@ -16,7 +16,7 @@ if ($category = $block->getProduct()->getCategory()) {
 <table id="product_protection_offers">
     <?php foreach ($block->getAssociatedProducts() as $product): ?>
         <tr>
-            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()); ?>" colspan="3" style="border-top: 0 !important"></td>
+            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= rawurlencode($product->getSku()); ?>" colspan="3" style="border-top: 0 !important"></td>
         </tr>
     <?php endforeach; ?>
 </table>
@@ -28,7 +28,7 @@ if ($category = $block->getProduct()->getCategory()) {
                     {
                         "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                         "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                        "selectedProductSku": "<?= $product->getSku() ?>",
+                        "selectedProductSku": "<?= $product->getSku(); ?>",
                         "selectedProductPrice": "<?= $product->getPrice(); ?>",
                         "productCategory": "<?= $categoryName; ?>"
                     }<?= array_key_last($block->getAssociatedProducts()) === $key ? '' : ',' ?>

--- a/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
@@ -7,6 +7,8 @@
 /** @var $block Magento\GroupedProduct\Block\Product\View\Type\Grouped */
 
 $categoryName = '';
+/** replace whitespace as being used as a div id */
+$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -16,7 +18,7 @@ if ($category = $block->getProduct()->getCategory()) {
 <table id="product_protection_offers">
     <?php foreach ($block->getAssociatedProducts() as $product): ?>
         <tr>
-            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= $product->getSku(); ?>" colspan="3" style="border-top: 0 !important"></td>
+            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= $normalizedProductSku; ?>" colspan="3" style="border-top: 0 !important"></td>
         </tr>
     <?php endforeach; ?>
 </table>
@@ -28,7 +30,7 @@ if ($category = $block->getProduct()->getCategory()) {
                     {
                         "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                         "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                        "selectedProductSku": "<?= $product->getSku(); ?>",
+                        "selectedProductSku": "<?= $normalizedProductSku; ?>",
                         "selectedProductPrice": "<?= $product->getPrice(); ?>",
                         "productCategory": "<?= $categoryName; ?>"
                     }<?= array_key_last($block->getAssociatedProducts()) === $key ? '' : ',' ?>

--- a/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
@@ -7,8 +7,6 @@
 /** @var $block Magento\GroupedProduct\Block\Product\View\Type\Grouped */
 
 $categoryName = '';
-/** encoding to prevent whitespace and other abnormal characters from being used in a div id */
-$encodedProductSku = urlencode($product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -18,7 +16,7 @@ if ($category = $block->getProduct()->getCategory()) {
 <table id="product_protection_offers">
     <?php foreach ($block->getAssociatedProducts() as $product): ?>
         <tr>
-            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= $encodedProductSku; ?>" colspan="3" style="border-top: 0 !important"></td>
+            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= rawurlencode($block->getProduct()->getSku()); ?>" colspan="3" style="border-top: 0 !important"></td>
         </tr>
     <?php endforeach; ?>
 </table>
@@ -30,7 +28,7 @@ if ($category = $block->getProduct()->getCategory()) {
                     {
                         "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                         "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                        "selectedProductSku": "<?= $encodedProductSku; ?>",
+                        "selectedProductSku": "<?= $product->getSku() ?>",
                         "selectedProductPrice": "<?= $product->getPrice(); ?>",
                         "productCategory": "<?= $categoryName; ?>"
                     }<?= array_key_last($block->getAssociatedProducts()) === $key ? '' : ',' ?>

--- a/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
+++ b/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
@@ -7,8 +7,8 @@
 /** @var $block Magento\GroupedProduct\Block\Product\View\Type\Grouped */
 
 $categoryName = '';
-/** replace whitespace as being used as a div id */
-$normalizedProductSku = preg_replace('/\s+/', '_', $product->getSku());
+/** encoding to prevent whitespace and other abnormal characters from being used in a div id */
+$encodedProductSku = urlencode($product->getSku());
 
 if ($category = $block->getProduct()->getCategory()) {
     $categoryName = $category->getName();
@@ -18,7 +18,7 @@ if ($category = $block->getProduct()->getCategory()) {
 <table id="product_protection_offers">
     <?php foreach ($block->getAssociatedProducts() as $product): ?>
         <tr>
-            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= $normalizedProductSku; ?>" colspan="3" style="border-top: 0 !important"></td>
+            <td class="product-protection-offer product-id-<?= $product->getEntityId(); ?>" id="product_protection_offer_<?= $encodedProductSku; ?>" colspan="3" style="border-top: 0 !important"></td>
         </tr>
     <?php endforeach; ?>
 </table>
@@ -30,7 +30,7 @@ if ($category = $block->getProduct()->getCategory()) {
                     {
                         "extendStoreUuid": "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                         "activeEnvironment": "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
-                        "selectedProductSku": "<?= $normalizedProductSku; ?>",
+                        "selectedProductSku": "<?= $encodedProductSku; ?>",
                         "selectedProductPrice": "<?= $product->getPrice(); ?>",
                         "productCategory": "<?= $categoryName; ?>"
                     }<?= array_key_last($block->getAssociatedProducts()) === $key ? '' : ',' ?>

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -59,7 +59,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
 
     Extend.buttons.renderSimpleOffer(
-      '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
+      '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
       activeProductData,
     )
   }

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -59,7 +59,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
 
     Extend.buttons.renderSimpleOffer(
-      '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
+      '#product_protection_offer_' + encodeURIComponent(config[0].selectedProductSku),
       activeProductData,
     )
   }

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -59,7 +59,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
 
     Extend.buttons.renderSimpleOffer(
-      '#product_protection_offer_' + config[0].selectedProductSku,
+      '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
       activeProductData,
     )
   }

--- a/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
@@ -45,7 +45,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     const productCategory = config[0].productCategory
 
     const addToCartButton = document
-      .querySelector('#product_protection_modal_offer_' + productSku.replace('/\s+/', '_'))
+      .querySelector('#product_protection_modal_offer_' + encodeURI(productSku))
       ?.closest('.product.actions.product-item-actions')
       ?.querySelector('.actions-primary')
       ?.querySelector('.action.tocart.primary')

--- a/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
@@ -45,7 +45,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     const productCategory = config[0].productCategory
 
     const addToCartButton = document
-      .querySelector('#product_protection_modal_offer_' + productSku)
+      .querySelector('#product_protection_modal_offer_' + productSku.replace('/\s+/', '_'))
       ?.closest('.product.actions.product-item-actions')
       ?.querySelector('.actions-primary')
       ?.querySelector('.action.tocart.primary')

--- a/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-modal-offer.js
@@ -45,7 +45,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
     const productCategory = config[0].productCategory
 
     const addToCartButton = document
-      .querySelector('#product_protection_modal_offer_' + encodeURI(productSku))
+      .querySelector('#product_protection_modal_offer_' + encodeURIComponent(productSku))
       ?.closest('.product.actions.product-item-actions')
       ?.querySelector('.actions-primary')
       ?.querySelector('.action.tocart.primary')

--- a/view/frontend/web/js/view/catalog/product/product-protection-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-offer.js
@@ -55,7 +55,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
 
     for (let key in config) {
-      Extend.buttons.render('#product_protection_offer_' + config[key].selectedProductSku, {
+      Extend.buttons.render('#product_protection_offer_' + config[key].selectedProductSku.replace('/\s+/', '_'), {
         referenceId: config[key].selectedProductSku,
         price: config[key].selectedProductPrice * 100,
       })
@@ -65,7 +65,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     $('div.product-options-wrapper', '.product-info-main').on('change', function () {
       const selectedProduct = getActiveProductConfig()
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + config[0].selectedProductSku,
+        '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
       )
       const activeProductData = {
         referenceId: selectedProduct.selectedProductSku,
@@ -75,7 +75,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
         buttonInstance.setActiveProduct(activeProductData)
       } else {
         Extend.buttons.render(
-          '#product_protection_offer_' + config[0].selectedProductSku,
+          '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
           activeProductData,
         )
       }
@@ -84,7 +84,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     // Listen for the add to cart button to be clicked.  Show modal offer on qualifying simple and configurable products if no offer was chosen by the customer.
     document.getElementById('product-addtocart-button').addEventListener('click', function () {
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + config[0].selectedProductSku,
+        '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
       )
 
       if (buttonInstance) {

--- a/view/frontend/web/js/view/catalog/product/product-protection-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-offer.js
@@ -55,17 +55,20 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     Extend.config({ storeId: config[0].extendStoreUuid, environment: config[0].activeEnvironment })
 
     for (let key in config) {
-      Extend.buttons.render('#product_protection_offer_' + config[key].selectedProductSku.replace('/\s+/', '_'), {
-        referenceId: config[key].selectedProductSku,
-        price: config[key].selectedProductPrice * 100,
-      })
+      Extend.buttons.render(
+        '#product_protection_offer_' + encodeURI(config[key].selectedProductSku),
+        {
+          referenceId: config[key].selectedProductSku,
+          price: config[key].selectedProductPrice * 100,
+        },
+      )
     }
 
     // Listening for product options being chosen on configurable products.  Display offer once all required options are chosen.
     $('div.product-options-wrapper', '.product-info-main').on('change', function () {
       const selectedProduct = getActiveProductConfig()
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
+        '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
       )
       const activeProductData = {
         referenceId: selectedProduct.selectedProductSku,
@@ -75,7 +78,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
         buttonInstance.setActiveProduct(activeProductData)
       } else {
         Extend.buttons.render(
-          '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
+          '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
           activeProductData,
         )
       }
@@ -84,7 +87,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     // Listen for the add to cart button to be clicked.  Show modal offer on qualifying simple and configurable products if no offer was chosen by the customer.
     document.getElementById('product-addtocart-button').addEventListener('click', function () {
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + config[0].selectedProductSku.replace('/\s+/', '_'),
+        '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
       )
 
       if (buttonInstance) {

--- a/view/frontend/web/js/view/catalog/product/product-protection-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-offer.js
@@ -56,7 +56,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
 
     for (let key in config) {
       Extend.buttons.render(
-        '#product_protection_offer_' + encodeURI(config[key].selectedProductSku),
+        '#product_protection_offer_' + encodeURIComponent(config[key].selectedProductSku),
         {
           referenceId: config[key].selectedProductSku,
           price: config[key].selectedProductPrice * 100,
@@ -68,7 +68,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     $('div.product-options-wrapper', '.product-info-main').on('change', function () {
       const selectedProduct = getActiveProductConfig()
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
+        '#product_protection_offer_' + encodeURIComponent(config[0].selectedProductSku),
       )
       const activeProductData = {
         referenceId: selectedProduct.selectedProductSku,
@@ -78,7 +78,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
         buttonInstance.setActiveProduct(activeProductData)
       } else {
         Extend.buttons.render(
-          '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
+          '#product_protection_offer_' + encodeURIComponent(config[0].selectedProductSku),
           activeProductData,
         )
       }
@@ -87,7 +87,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
     // Listen for the add to cart button to be clicked.  Show modal offer on qualifying simple and configurable products if no offer was chosen by the customer.
     document.getElementById('product-addtocart-button').addEventListener('click', function () {
       const buttonInstance = Extend.buttons.instance(
-        '#product_protection_offer_' + encodeURI(config[0].selectedProductSku),
+        '#product_protection_offer_' + encodeURIComponent(config[0].selectedProductSku),
       )
 
       if (buttonInstance) {


### PR DESCRIPTION
# Description

Product sku's in magento can have whitespace. div id's are not supposed to have whitespace (and a bug was run into for this reason), normalize product sku's to not have whitespace for fetches within the html. 

One question is if we want to replace with a character less common than underscore (url encoding?), since there is an issue if "Baguette Loafers" and "Baguette_Loafers" are both different valid skus and get added to a cart at the same time there would be an error. I think that edge case is pretty unlikely though.

## Ticket

List your ticket here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
