### PR TITLE
[PAR-4828] str_contains deprecation null check

### DIFF
--- a/Block/Adminhtml/Integration/Edit/Tab/Stores.php
+++ b/Block/Adminhtml/Integration/Edit/Tab/Stores.php
@@ -121,10 +121,12 @@ class Stores extends \Magento\Backend\Block\Widget\Form\Generic implements
         $integrationData = $this->_coreRegistry->registry(
             Integration::REGISTRY_KEY_CURRENT_INTEGRATION
         );
+
         if (
             isset($integrationData['integration_id']) &&
-            str_contains($integrationData['endpoint'], 'extend.com') &&
-            str_contains($integrationData['endpoint'], 'integ-mage')
+            ($integrationData['endpoint'] === null ||
+                (str_contains($integrationData['endpoint'], 'extend.com') &&
+                    str_contains($integrationData['endpoint'], 'integ-mage')))
         ) {
             return true;
         }

--- a/Block/Adminhtml/Integration/Edit/Tab/Stores.php
+++ b/Block/Adminhtml/Integration/Edit/Tab/Stores.php
@@ -124,9 +124,9 @@ class Stores extends \Magento\Backend\Block\Widget\Form\Generic implements
 
         if (
             isset($integrationData['integration_id']) &&
-            ($integrationData['endpoint'] === null ||
-                (str_contains($integrationData['endpoint'], 'extend.com') &&
-                    str_contains($integrationData['endpoint'], 'integ-mage')))
+            isset($integrationData['endpoint']) &&
+            (str_contains($integrationData['endpoint'], 'extend.com') &&
+                str_contains($integrationData['endpoint'], 'integ-mage'))
         ) {
             return true;
         }

--- a/Preference/Framework/Http/ZendClientPreference.php
+++ b/Preference/Framework/Http/ZendClientPreference.php
@@ -10,9 +10,9 @@ class ZendClientPreference extends \Magento\Framework\HTTP\ZendClient
 {
     protected function _trySetCurlAdapter()
     {
-        $host = $this->getUri() ? $this->getUri()->getHost() : null;
+        $host = $this->getUri()->getHost();
 
-        if (str_contains($host, 'extend.com')) {
+        if ($host !== null && str_contains($host, 'extend.com')) {
             $this->setAdapter('Zend_Http_Client_Adapter_Curl');
         } else {
             if (extension_loaded('curl')) {

--- a/Preference/Framework/Http/ZendClientPreference.php
+++ b/Preference/Framework/Http/ZendClientPreference.php
@@ -10,7 +10,9 @@ class ZendClientPreference extends \Magento\Framework\HTTP\ZendClient
 {
     protected function _trySetCurlAdapter()
     {
-        if (str_contains($this->getUri()->getHost(), 'extend.com')) {
+        $host = $this->getUri()?->getHost() ?? null;
+
+        if (str_contains($host, 'extend.com')) {
             $this->setAdapter('Zend_Http_Client_Adapter_Curl');
         } else {
             if (extension_loaded('curl')) {

--- a/Preference/Framework/Http/ZendClientPreference.php
+++ b/Preference/Framework/Http/ZendClientPreference.php
@@ -10,7 +10,7 @@ class ZendClientPreference extends \Magento\Framework\HTTP\ZendClient
 {
     protected function _trySetCurlAdapter()
     {
-        $host = $this->getUri()?->getHost() ?? null;
+        $host = $this->getUri() ? $this->getUri()->getHost() : null;
 
         if (str_contains($host, 'extend.com')) {
             $this->setAdapter('Zend_Http_Client_Adapter_Curl');

--- a/Service/Api/ActiveEnvironmentURLBuilder.php
+++ b/Service/Api/ActiveEnvironmentURLBuilder.php
@@ -74,14 +74,14 @@ class ActiveEnvironmentURLBuilder
         return $this->getEnvironmentFromURL($url) === 'prod';
     }
 
-    public function getEnvironmentFromURL(string $url): string
+    public function getEnvironmentFromURL(?string $url): string
     {
-        if (str_contains($url, 'https://integ-mage-')) {
+        if ($url !== null && str_contains($url, 'https://integ-mage-')) {
             $urlParts = explode('https://integ-mage-', $url);
             $urlParts = explode('.', $urlParts[1]);
             return $urlParts[0];
         }
-        if (str_contains($url, 'https://integ-mage.')) {
+        if ($url !== null && str_contains($url, 'https://integ-mage.')) {
             return 'prod';
         }
         return '';


### PR DESCRIPTION
# Description
* explicitly null check `str_contains` first parameter prevent deprecation error in PHP 8.1 and greater

## Ticket
https://helloextend.atlassian.net/browse/PAR-4828

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
