### PR TITLE
[PAR-4463] Display Plan Details

### DIFF
--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -419,8 +419,8 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
 
     /**
      * Creates the product options for the product protection item
-     * These options won't appear on the FE via not defining the "option_ids" option
-     * They are converted to order at extension attributes when retrieving an order
+     * These options will not appear on the storefront/admin because the "option_ids" option is not included
+     * They are converted to order extension attributes when retrieving an order
      *
      * @param $product
      * @param $item
@@ -449,7 +449,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
 
     /**
      * Adds additional options to the product protection quote item
-     * These are used to display the product protection information on the FE
+     * These are used to display the product protection information on the storefront/admin
      * They are also leveraged by the Magento SDK add-on (e.g. normalization)
      *
      * @param $item

--- a/Plugin/Model/OrderItemRepositoryPlugin.php
+++ b/Plugin/Model/OrderItemRepositoryPlugin.php
@@ -6,6 +6,7 @@
 
 namespace Extend\Integration\Plugin\Model;
 
+use Extend\Integration\Model\ProductProtection;
 use Extend\Integration\Model\ProductProtectionFactory;
 use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Api\Data\OrderItemSearchResultInterface;
@@ -76,34 +77,33 @@ class OrderItemRepositoryPlugin
 
                     // for each of the product's configured options, set the corresponding extension attribute
                     // according to the quote item's corresponding option value.
-                    foreach ($productOptions as $o) {
-                        $optionId = $o->getId();
-                        if ($existingOption = $quoteItem->getOptionByCode("option_$optionId")) {
-                            $optionTitle = $o->getTitle();
+                    foreach (ProductProtection::CUSTOM_OPTION_CODES as $optionCode) {
+                        $existingOption = $quoteItem->getOptionByCode($optionCode);
+                        if ($existingOption) {
                             $optionValue = $existingOption->getValue();
-                            switch ($optionTitle) {
-                                case 'Plan ID':
+                            switch ($optionCode) {
+                                case ProductProtection::PLAN_ID_CODE:
                                     $productProtection->setPlanId($optionValue);
                                     break;
-                                case 'Plan Type':
+                                case ProductProtection::PLAN_TYPE_CODE:
                                     $productProtection->setPlanType($optionValue);
                                     break;
-                                case 'Associated Product':
+                                case ProductProtection::ASSOCIATED_PRODUCT_SKU_CODE:
                                     $productProtection->setAssociatedProduct($optionValue);
                                     break;
-                                case 'Term':
+                                case ProductProtection::TERM_CODE:
                                     $productProtection->setTerm($optionValue);
                                     break;
-                                case 'Order Offer Plan Id':
+                                case ProductProtection::OFFER_PLAN_ID_CODE:
                                     $productProtection->setOfferPlanId($optionValue);
                                     break;
-                                case 'List Price':
+                                case ProductProtection::LIST_PRICE_CODE:
                                     $productProtection->setListPrice($optionValue);
                                     break;
-                                case 'Lead Token':
+                                case ProductProtection::LEAD_TOKEN_CODE:
                                     $productProtection->setLeadtoken($optionValue);
                                     break;
-                                case 'Lead Quantity':
+                                case ProductProtection::LEAD_QUANTITY_CODE:
                                     $productProtection->setLeadQuantity($optionValue);
                                     break;
                             }

--- a/Plugin/Model/Quote/Item/ToOrderItemPlugin.php
+++ b/Plugin/Model/Quote/Item/ToOrderItemPlugin.php
@@ -23,6 +23,15 @@ class ToOrderItemPlugin
         $this->serializer = $serializer;
     }
 
+    /**
+     * After converting quote item to order item, migrate additional options to order item
+     *
+     * @param QuoteToOrderItem $subject
+     * @param OrderItem $orderItem
+     * @param AbstractItem $quoteItem
+     * @param array $data
+     * @return OrderItem
+     */
     public function afterConvert(
         QuoteToOrderItem $subject,
         OrderItem $orderItem,

--- a/Plugin/Model/Quote/Item/ToOrderItemPlugin.php
+++ b/Plugin/Model/Quote/Item/ToOrderItemPlugin.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright Extend (c) 2023. All rights reserved.
+ * See Extend-COPYING.txt for license details.
+ */
+
+namespace Extend\Integration\Plugin\Model\Quote\Item;
+
+use Magento\Quote\Model\Quote\Item\ToOrderItem as QuoteToOrderItem;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
+
+class ToOrderItemPlugin
+{
+    /**
+     * @var SerializerInterface
+     */
+    private SerializerInterface $serializer;
+
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    public function afterConvert(
+        QuoteToOrderItem $subject,
+        OrderItem $orderItem,
+        AbstractItem $quoteItem,
+        $data = []
+    ) {
+        $additionalOptions = $quoteItem->getOptionByCode('additional_options');
+        if ($additionalOptions) {
+            $options = $orderItem->getProductOptions();
+            $options['additional_options'] = $this->serializer->unserialize(
+                $additionalOptions->getValue()
+            );
+            $orderItem->setProductOptions($options);
+        }
+
+        return $orderItem;
+    }
+}

--- a/Service/Extend.php
+++ b/Service/Extend.php
@@ -14,6 +14,11 @@ class Extend
     public const WARRANTY_PRODUCT_SKU = 'extend-protection-plan';
 
     /**
+     * warranty product name
+     */
+    public const WARRANTY_PRODUCT_NAME = 'Extend Protection Plan';
+
+    /**
      * warranty product sku
      */
     public const WARRANTY_PRODUCT_ATTRIBUTE_SET_NAME = 'Extend Products';

--- a/Setup/Model/ProductInstaller.php
+++ b/Setup/Model/ProductInstaller.php
@@ -152,7 +152,7 @@ class ProductInstaller
 
             $product
                 ->setSku(Extend::WARRANTY_PRODUCT_SKU)
-                ->setName('Extend Protection Plan')
+                ->setName(Extend::WARRANTY_PRODUCT_NAME)
                 ->setWebsiteIds(array_keys($this->storeManager->getWebsites()))
                 ->setAttributeSetId($attributeSet->getAttributeSetId())
                 ->setStatus(Status::STATUS_ENABLED)

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,4 +48,7 @@
     <type name="Magento\Sales\Api\OrderItemRepositoryInterface">
         <plugin sortOrder="1" name="extendIntegrationOrderItemRepository" type="Extend\Integration\Plugin\Model\OrderItemRepositoryPlugin" />
     </type>
+    <type name="Magento\Quote\Model\Quote\Item\ToOrderItem">
+        <plugin name="extendIntegrationToOrderItem" type="Extend\Integration\Plugin\Model\Quote\Item\ToOrderItemPlugin" />
+    </type>
 </config>


### PR DESCRIPTION
# Description

- Add "additional options" to be used for displaying product options on the storefront and within admin
- Update "hidden options" to be saved under a code and remove the "option_ids" option so that they do not appear on the storefront and within admin
- Plugin to migrate additional options when converting quote items to order items
![Screen Shot 2023-07-06 at 10 23 19 AM](https://github.com/helloextend/magento-extend-integration/assets/6566341/a8023e57-eb30-4f78-8b6a-705fcbf3c04a)
![Screen Shot 2023-07-06 at 10 23 25 AM](https://github.com/helloextend/magento-extend-integration/assets/6566341/e1c498d1-2714-41b4-9141-157e3045be6f)
![Screen Shot 2023-07-06 at 10 23 37 AM](https://github.com/helloextend/magento-extend-integration/assets/6566341/724981a3-ad22-4a53-99cd-fcce5d32ad36)
![Screen Shot 2023-07-06 at 10 23 03 AM](https://github.com/helloextend/magento-extend-integration/assets/6566341/2c33f6bd-4fd3-4ba5-8524-2752590c379c)


## Ticket

https://helloextend.atlassian.net/browse/PAR-4463

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
