### PR TITLE
[PAR-4854] Product Protection Upsert via Cart ID

### DIFF
--- a/Api/ProductProtectionInterface.php
+++ b/Api/ProductProtectionInterface.php
@@ -146,8 +146,8 @@ interface ProductProtectionInterface
     public function getListPrice(): ?string;
 
     /**
-     * Upsert product protection in cart from storefront
-     * Utilizes checkout session which is only available for calls coming from the storefront
+     * Upsert product protection in cart via checkout session
+     * Utilizes checkout session which is only available for calls made from the storefront
      *
      * @param int|null $quantity
      * @param string|null $cartItemId
@@ -177,8 +177,7 @@ interface ProductProtectionInterface
     ): void;
 
     /**
-     * Upsert product protection in cart as an admin
-     * Utilizes a cart id instead of the checkout session which is only available for calls coming from the storefront
+     * Upsert product protection in cart via cart id
      *
      * @param int|null $quantity
      * @param string|null $cartId

--- a/Api/ProductProtectionInterface.php
+++ b/Api/ProductProtectionInterface.php
@@ -163,7 +163,7 @@ interface ProductProtectionInterface
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsertStorefront(
+    public function upsertSession(
         int $quantity = null,
         string $cartItemId = null,
         string $productId = null,
@@ -195,7 +195,7 @@ interface ProductProtectionInterface
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsertAdmin(
+    public function upsertCartId(
         int $quantity = null,
         string $cartId = null,
         string $cartItemId = null,

--- a/Api/ProductProtectionInterface.php
+++ b/Api/ProductProtectionInterface.php
@@ -146,7 +146,8 @@ interface ProductProtectionInterface
     public function getListPrice(): ?string;
 
     /**
-     * Upsert product protection in cart
+     * Upsert product protection in cart from storefront
+     * Utilizes checkout session which is only available for calls coming from the storefront
      *
      * @param int|null $quantity
      * @param string|null $cartItemId
@@ -162,8 +163,41 @@ interface ProductProtectionInterface
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsert(
+    public function upsertStorefront(
         int $quantity = null,
+        string $cartItemId = null,
+        string $productId = null,
+        string $planId = null,
+        int $price = null,
+        int $term = null,
+        string $coverageType = null,
+        string $leadToken = null,
+        string $listPrice = null,
+        string $orderOfferPlanId = null
+    ): void;
+
+    /**
+     * Upsert product protection in cart as an admin
+     * Utilizes a cart id instead of the checkout session which is only available for calls coming from the storefront
+     *
+     * @param int|null $quantity
+     * @param string|null $cartId
+     * @param string|null $cartItemId
+     * @param string|null $productId
+     * @param string|null $planId
+     * @param int|null $price
+     * @param int|null $term
+     * @param string|null $coverageType
+     * @param string|null $leadToken
+     * @param string|null $listPrice
+     * @param string|null $orderOfferPlanId
+     * @return void
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function upsertAdmin(
+        int $quantity = null,
+        string $cartId = null,
         string $cartItemId = null,
         string $productId = null,
         string $planId = null,

--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -20,6 +20,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
 use Exception;
 
 class ProductProtection extends \Magento\Framework\Model\AbstractModel implements
@@ -86,6 +87,11 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
     private SerializerInterface $serializer;
 
     /**
+     * @var MaskedQuoteIdToQuoteIdInterface
+     */
+    private MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId;
+
+    /**
      * @return void
      */
     public function __construct(
@@ -97,7 +103,8 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
         Integration $integration,
         StoreManagerInterface $storeManager,
         LoggerInterface $logger,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId
     ) {
         $this->logger = $logger;
         $this->quoteRepository = $quoteRepository;
@@ -108,6 +115,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
         $this->storeManager = $storeManager;
         $this->productRepository = $productRepository;
         $this->serializer = $serializer;
+        $this->maskedQuoteIdToQuoteId = $maskedQuoteIdToQuoteId;
     }
 
     /**
@@ -282,6 +290,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
      * Upsert product protection in cart
      *
      * @param int|null $quantity
+     * @param string|null $cartId
      * @param string|null $cartItemId
      * @param string|null $productId
      * @param string|null $planId
@@ -295,8 +304,9 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsert(
+    private function upsert(
         int $quantity = null,
+        string $cartId = null,
         string $cartItemId = null,
         string $productId = null,
         string $planId = null,
@@ -314,8 +324,20 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                 );
             }
 
+            $unmaskedCartId = null;
+            if ($cartId) {
+                try {
+                    $unmaskedCartId = $this->maskedQuoteIdToQuoteId->execute($cartId);
+                    $quote = $this->quoteRepository->get($unmaskedCartId);
+                } catch (NoSuchEntityException $exception) {
+                    throw new LocalizedException(new Phrase('Cart not found'));
+                }
+            } else {
+                $quote = $this->checkoutSession->getQuote();
+            }
+
             if (isset($cartItemId)) {
-                $item = $this->checkoutSession->getQuote()->getItemById($cartItemId);
+                $item = $quote->getItemById($cartItemId);
                 if ($item->getProduct()->getSku() !== Extend::WARRANTY_PRODUCT_SKU) {
                     throw new LocalizedException(
                         new Phrase('Cannot update non product-protection item')
@@ -328,9 +350,6 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                     new Phrase('Cannot remove product protection without cart item id')
                 );
             }
-
-            // get the quote
-            $quote = $this->checkoutSession->getQuote();
 
             // if quantity is 0, remove the item from the quote
             if ($quantity === 0 && isset($cartItemId)) {
@@ -398,7 +417,11 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
             $this->quoteRepository->save($quote);
 
             // fetch the quote once more so that the new item is loaded
-            $quote = $this->checkoutSession->getQuote();
+            if ($unmaskedCartId) {
+                $quote = $this->quoteRepository->get($unmaskedCartId);
+            } else {
+                $quote = $this->checkoutSession->getQuote();
+            }
 
             //save the quote once more with the totals collected
             $this->quoteRepository->save($quote->collectTotals());
@@ -415,6 +438,98 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
             // this is handled by magento error handler
             throw $exception;
         }
+    }
+
+    /**
+     * Upsert product protection in cart from storefront
+     * Utilizes checkout session which is only available for calls coming from the storefront
+     *
+     * @param int|null $quantity
+     * @param string|null $cartItemId
+     * @param string|null $productId
+     * @param string|null $planId
+     * @param int|null $price
+     * @param int|null $term
+     * @param string|null $coverageType
+     * @param string|null $leadToken
+     * @param string|null $listPrice
+     * @param string|null $orderOfferPlanId
+     * @return void
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function upsertStorefront(
+        int $quantity = null,
+        string $cartItemId = null,
+        string $productId = null,
+        string $planId = null,
+        int $price = null,
+        int $term = null,
+        string $coverageType = null,
+        string $leadToken = null,
+        string $listPrice = null,
+        string $orderOfferPlanId = null
+    ): void {
+        $this->upsert(
+            $quantity,
+            null,
+            $cartItemId,
+            $productId,
+            $planId,
+            $price,
+            $term,
+            $coverageType,
+            $leadToken,
+            $listPrice,
+            $orderOfferPlanId
+        );
+    }
+
+    /**
+     * Upsert product protection in cart as an admin
+     * Utilizes a cart id instead of the checkout session which is only available for calls coming from the storefront
+     *
+     * @param int|null $quantity
+     * @param string|null $cartId
+     * @param string|null $cartItemId
+     * @param string|null $productId
+     * @param string|null $planId
+     * @param int|null $price
+     * @param int|null $term
+     * @param string|null $coverageType
+     * @param string|null $leadToken
+     * @param string|null $listPrice
+     * @param string|null $orderOfferPlanId
+     * @return void
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function upsertAdmin(
+        int $quantity = null,
+        string $cartId = null,
+        string $cartItemId = null,
+        string $productId = null,
+        string $planId = null,
+        int $price = null,
+        int $term = null,
+        string $coverageType = null,
+        string $leadToken = null,
+        string $listPrice = null,
+        string $orderOfferPlanId = null
+    ): void {
+        $this->upsert(
+            $quantity,
+            $cartId,
+            $cartItemId,
+            $productId,
+            $planId,
+            $price,
+            $term,
+            $coverageType,
+            $leadToken,
+            $listPrice,
+            $orderOfferPlanId
+        );
     }
 
     /**

--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -441,8 +441,8 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
     }
 
     /**
-     * Upsert product protection in cart from storefront
-     * Utilizes checkout session which is only available for calls coming from the storefront
+     * Upsert product protection in cart via checkout session
+     * Utilizes checkout session which is only available for calls made from the storefront
      *
      * @param int|null $quantity
      * @param string|null $cartItemId
@@ -486,8 +486,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
     }
 
     /**
-     * Upsert product protection in cart as an admin
-     * Utilizes a cart id instead of the checkout session which is only available for calls coming from the storefront
+     * Upsert product protection in cart via cart id
      *
      * @param int|null $quantity
      * @param string|null $cartId

--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -458,7 +458,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsertStorefront(
+    public function upsertSession(
         int $quantity = null,
         string $cartItemId = null,
         string $productId = null,
@@ -504,7 +504,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function upsertAdmin(
+    public function upsertCartId(
         int $quantity = null,
         string $cartId = null,
         string $cartItemId = null,

--- a/Setup/Model/ProductInstaller.php
+++ b/Setup/Model/ProductInstaller.php
@@ -101,7 +101,7 @@ class ProductInstaller
             if ($product = $this->createProtectionPlanProduct($attributeSet)) {
                 $this->addImageToPubMedia();
                 $this->processMediaGalleryEntry($this->getMediaImagePath(), $product->getSku());
-                // $this->addOptionsToProtectionPlanProduct($product);
+                $this->addOptionsToProtectionPlanProduct($product);
                 $this->createSourceItem();
             }
         } catch (Exception $exception) {

--- a/Setup/Model/ProductInstaller.php
+++ b/Setup/Model/ProductInstaller.php
@@ -101,7 +101,7 @@ class ProductInstaller
             if ($product = $this->createProtectionPlanProduct($attributeSet)) {
                 $this->addImageToPubMedia();
                 $this->processMediaGalleryEntry($this->getMediaImagePath(), $product->getSku());
-                $this->addOptionsToProtectionPlanProduct($product);
+                // $this->addOptionsToProtectionPlanProduct($product);
                 $this->createSourceItem();
             }
         } catch (Exception $exception) {

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -73,13 +73,13 @@
         </resources>
     </route>
     <route url="/V1/extend/integration/pp/upsert" method="POST">
-        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertStorefront" />
+        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertSession" />
         <resources>
             <resource ref="anonymous" />
         </resources>
     </route>
     <route url="/V1/extend/integration/pp/upsert/:cart_id" method="POST">
-        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertAdmin" />
+        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertCartId" />
         <resources>
             <resource ref="Extend_Integration::manage" />
         </resources>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -73,9 +73,15 @@
         </resources>
     </route>
     <route url="/V1/extend/integration/pp/upsert" method="POST">
-        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsert" />
+        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertStorefront" />
         <resources>
             <resource ref="anonymous" />
+        </resources>
+    </route>
+    <route url="/V1/extend/integration/pp/upsert/:cart_id" method="POST">
+        <service class="Extend\Integration\Api\ProductProtectionInterface" method="upsertAdmin" />
+        <resources>
+            <resource ref="Extend_Integration::manage" />
         </resources>
     </route>
 </routes>


### PR DESCRIPTION
# Description

- New protected endpoint to allow for product protection upsert via cart id
- For things like Cypress tests that prioritize API calls over UI interactions, since we aren't interacting with the storefront, the upsert call we usually make cannot be utilized (i.e. since no checkout session is attached when made from elsewhere)
- Additional endpoint will be closer to that logic as they funnel into the same function

## Ticket

https://helloextend.atlassian.net/browse/PAR-4854

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
