### PR TITLE
fix:  [PAR-4932] fix skus property name

### DIFF
--- a/view/frontend/web/js/view/catalog/product/product-protection-offer.js
+++ b/view/frontend/web/js/view/catalog/product/product-protection-offer.js
@@ -38,7 +38,7 @@ define(['jquery', 'cartUtils', 'extendSdk', 'ExtendMagento'], function (
         if (selectedId && selectedId !== '') {
           selectedPrice =
             swatchRenderer.options.jsonConfig.optionPrices[selectedId].finalPrice.amount
-          selectedProductSku = swatchRenderer.options.jsonConfig.skus[selectedId]
+          selectedProductSku = swatchRenderer.options.jsonConfig.sku[selectedId]
         }
       }
     } else {


### PR DESCRIPTION
# Description

here is an example of the `jsonConfig` object

```
{
    "attributes": [
        // etc etc etc
    ],
    "template": "$<%- data.price %>",
    "currencyFormat": "$%s",
    "optionPrices": {
       //  etc etc etc
    },
    "priceFormat": {
        "pattern": "$%s",
        "precision": 2,
        "requiredPrecision": 2,
        "decimalSymbol": ".",
        "groupSymbol": ",",
        "groupLength": 3,
        "integerRequired": false
    },
    "prices": {
        // etc etc etc
    },
    "productId": "62",
    "chooseText": "Choose an Option...",
    "images": {
        // etc etc etc
    },
    "index": {
        // etc etc etc
    },
    "channel": "website",
    "salesChannelCode": "base",
    "sku": {
        "47": "MH01-XS-Black",
        "48": "MH01-XS-Gray",
        "49": "MH01-XS-Orange",
        "50": "MH01-S-Black",
        "51": "MH01-S-Gray",
        "52": "MH01-S-Orange",
        "53": "MH01-M-Black",
        "54": "MH01-M-Gray",
        "55": "MH01-M-Orange",
        "56": "MH01-L-Black",
        "57": "MH01-L-Gray",
        "58": "MH01-L-Orange",
        "59": "MH01-XL-Black",
        "60": "MH01-XL-Gray",
        "61": "MH01-XL-Orange"
    },
    "mappedAttributes": {
        // etc etc etc
}
```

note that the property we're looking for is `sku`, not `skus` 🙂

* verified that offers display now on configurable objects once the attributes are selected
* verified no related console errors when adding the product to the cart a) by itself or b) with a protection plan
* verified the offer modal displays if a variant is added to the cart without selecting a plan from the PDP offer

## Ticket

https://helloextend.atlassian.net/browse/PAR-4932

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
