### PR TITLE
bugfix: [PAR-4922] Refresh Cart Page if PP added from simple offer

### DIFF
--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -3,12 +3,7 @@
  * See Extend-COPYING.txt for license details.
  */
 
-define(['cartUtils', 'extendSdk', 'ExtendMagento', 'Magento_Customer/js/customer-data'], function (
-  cartUtils,
-  Extend,
-  ExtendMagento,
-  customerData,
-) {
+define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend, ExtendMagento) {
   'use strict'
 
   const getProductQuantity = function (cartItems, product) {
@@ -44,19 +39,12 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento', 'Magento_Customer/js/customer
         offerId,
         quantity: quantity ?? getProductQuantity(cartItems, product),
       }).then(function () {
-        const cartData = cartUtils.getCartData()
-
-        cartData.subscribe(function (_updatedCartData) {
-          window.location.reload()
-        })
-
-        // This will trigger the above subscribe function. When we simply
-        // tried to call window.location.reload() here the result would be
-        // that we'd see an updated cart but the offer would still show because
-        // the underlying cart values would be missing the newly added virtual item
-        const sectionsToUpdate = ['cart']
-        customerData.invalidate(sectionsToUpdate)
-        customerData.reload(sectionsToUpdate, true)
+        // The underlying code in the refreshMiniCart function forces a cart
+        // invalidation that effects more than just the mini cart. We rely on this
+        // to happen before refreshing so that we never get a stale state where the
+        // refreshed page cart is missing the virtual product and thus tries to show offers.
+        cartUtils.refreshMiniCart()
+        window.location.reload()
       })
     }
   }

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -3,7 +3,12 @@
  * See Extend-COPYING.txt for license details.
  */
 
-define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend, ExtendMagento) {
+define(['cartUtils', 'extendSdk', 'ExtendMagento', 'Magento_Customer/js/customer-data'], function (
+  cartUtils,
+  Extend,
+  ExtendMagento,
+  customerData,
+) {
   'use strict'
 
   const getProductQuantity = function (cartItems, product) {
@@ -38,7 +43,21 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento'], function (cartUtils, Extend,
         listPrice,
         offerId,
         quantity: quantity ?? getProductQuantity(cartItems, product),
-      }).then(cartUtils.refreshMiniCart)
+      }).then(function () {
+        const cartData = cartUtils.getCartData()
+
+        cartData.subscribe(function (_updatedCartData) {
+          window.location.reload()
+        })
+
+        // This will trigger the above subscribe function. When we simply
+        // tried to call window.location.reload() here the result would be
+        // that we'd see an updated cart but the offer would still show because
+        // the underlying cart values would be missing the newly added virtual item
+        const sectionsToUpdate = ['cart']
+        customerData.invalidate(sectionsToUpdate)
+        customerData.reload(sectionsToUpdate, true)
+      })
     }
   }
 


### PR DESCRIPTION
# Description

Previously when added a new plan via the simple offer button on the Cart page we updated only the mini cart. Now we're updating the entire cart which forces a page reload.

https://github.com/helloextend/magento-extend-integration/assets/120399500/ef6a9e88-6ce9-4638-8249-5a925185f465

## Ticket

https://helloextend.atlassian.net/browse/PAR-4922

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
