### PR TITLE
feature: [PAR-4934] update offer display settings to be settable and retrievable in multiple scope contexts and add minicart display setting toggle

### DIFF
--- a/Model/Config/Backend/Enable.php
+++ b/Model/Config/Backend/Enable.php
@@ -50,24 +50,14 @@ class Enable extends Value
     {
         $isV2Enabled = (int) $this->getValue();
         if ($isV2Enabled === 0) {
-            $this->writer->save(\Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION, 0);
-            $this->writer->save(\Extend\Integration\Service\Extend::ENABLE_SHIPPING_PROTECTION, 0);
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_CART_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_DISPLAY_PAGE_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_CATALOG_PAGE_MODAL_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_POST_PURCHASE_LEAD_MODAL_OFFER,
-                0
-            );
+            $dependentConfigPaths = [
+                \Extend\Integration\Service\Extend::ENABLE_SHIPPING_PROTECTION,
+                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION,
+            ];
+
+            foreach ($dependentConfigPaths as $path) {
+                $this->writer->save($path, 0);
+            }
         }
         return parent::afterSave();
     }

--- a/Model/Config/Backend/EnableProductProtection.php
+++ b/Model/Config/Backend/EnableProductProtection.php
@@ -10,19 +10,17 @@ use Magento\Framework\App\Config\Value;
 use Extend\Integration\Setup\Model\AttributeSetInstaller;
 use Extend\Integration\Setup\Model\ProductInstaller;
 use Magento\Framework\App\Config\Storage\WriterInterface;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class EnableProductProtection extends Value
 {
     private AttributeSetInstaller $attributeSetInstaller;
     private ProductInstaller $productInstaller;
     private WriterInterface $writer;
-    private ScopeConfigInterface $config;
 
     public function __construct(
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
-        ScopeConfigInterface $config,
+        \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         AttributeSetInstaller $attributeSetInstaller,
         ProductInstaller $productInstaller,
@@ -41,7 +39,6 @@ class EnableProductProtection extends Value
         $this->attributeSetInstaller = $attributeSetInstaller;
         $this->productInstaller = $productInstaller;
         $this->writer = $writer;
-        $this->config = $config;
     }
 
     /**

--- a/Model/Config/Backend/EnableProductProtection.php
+++ b/Model/Config/Backend/EnableProductProtection.php
@@ -10,17 +10,19 @@ use Magento\Framework\App\Config\Value;
 use Extend\Integration\Setup\Model\AttributeSetInstaller;
 use Extend\Integration\Setup\Model\ProductInstaller;
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class EnableProductProtection extends Value
 {
     private AttributeSetInstaller $attributeSetInstaller;
     private ProductInstaller $productInstaller;
     private WriterInterface $writer;
+    private ScopeConfigInterface $config;
 
     public function __construct(
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
-        \Magento\Framework\App\Config\ScopeConfigInterface $config,
+        ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         AttributeSetInstaller $attributeSetInstaller,
         ProductInstaller $productInstaller,
@@ -39,6 +41,7 @@ class EnableProductProtection extends Value
         $this->attributeSetInstaller = $attributeSetInstaller;
         $this->productInstaller = $productInstaller;
         $this->writer = $writer;
+        $this->config = $config;
     }
 
     /**
@@ -53,23 +56,6 @@ class EnableProductProtection extends Value
         if ($isPPV2Enabled === 1) {
             $attributeSet = $this->attributeSetInstaller->createAttributeSet();
             $this->productInstaller->createProduct($attributeSet);
-        } else {
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_CART_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_DISPLAY_PAGE_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_POST_PURCHASE_LEAD_MODAL_OFFER,
-                0
-            );
-            $this->writer->save(
-                \Extend\Integration\Service\Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_CATALOG_PAGE_MODAL_OFFER,
-                0
-            );
         }
         return parent::afterSave();
     }

--- a/Service/Extend.php
+++ b/Service/Extend.php
@@ -37,6 +37,7 @@ class Extend
     public const ENABLE_EXTEND = 'extend/integration/enable';
 
     public const ENABLE_PRODUCT_PROTECTION_CART_OFFER = 'extend_plans/product_protection/offer_display_settings/enable_cart_offer';
+    public const ENABLE_PRODUCT_PROTECTION_MINICART_OFFER = 'extend_plans/product_protection/offer_display_settings/enable_minicart_offer';
     public const ENABLE_PRODUCT_PROTECTION_PRODUCT_DISPLAY_PAGE_OFFER = 'extend_plans/product_protection/offer_display_settings/enable_pdp_offer';
     public const ENABLE_PRODUCT_PROTECTION_POST_PURCHASE_LEAD_MODAL_OFFER = 'extend_plans/product_protection/offer_display_settings/enable_post_purchase_lead_modal_offer';
     public const ENABLE_PRODUCT_PROTECTION_PRODUCT_CATALOG_PAGE_MODAL_OFFER = 'extend_plans/product_protection/offer_display_settings/enable_product_catalog_page_modal_offer';

--- a/ViewModel/EnvironmentAndExtendStoreUuid.php
+++ b/ViewModel/EnvironmentAndExtendStoreUuid.php
@@ -94,7 +94,7 @@ class EnvironmentAndExtendStoreUuid implements
 
     public function isCartBalancingEnabled(): bool
     {
-        return $this->scopeConfig->getValue(Extend::ENABLE_CART_BALANCING) === '1';
+        return $this->getScopedConfigValue(Extend::ENABLE_CART_BALANCING) === '1';
     }
 
     public function isProductProtectionProductDisplayPageOfferEnabled(): bool

--- a/ViewModel/EnvironmentAndExtendStoreUuid.php
+++ b/ViewModel/EnvironmentAndExtendStoreUuid.php
@@ -12,6 +12,7 @@ use Extend\Integration\Service\Api\ActiveEnvironmentURLBuilder;
 use Extend\Integration\Service\Api\Integration;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\ScopeInterface;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\App\Request\Http;
 
@@ -88,33 +89,51 @@ class EnvironmentAndExtendStoreUuid implements
 
     public function isExtendProductProtectionEnabled(): bool
     {
-        return $this->scopeConfig->getValue(Extend::ENABLE_PRODUCT_PROTECTION) === '1';
+        return $this->getScopedConfigValue(Extend::ENABLE_PRODUCT_PROTECTION) === '1';
     }
 
     public function isProductProtectionProductDisplayPageOfferEnabled(): bool
     {
-        return $this->scopeConfig->getValue(
+        return $this->getScopedConfigValue(
             Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_DISPLAY_PAGE_OFFER
         ) === '1';
     }
 
     public function isProductProtectionCartOfferEnabled(): bool
     {
-        return $this->scopeConfig->getValue(Extend::ENABLE_PRODUCT_PROTECTION_CART_OFFER) === '1';
+        return $this->getScopedConfigValue(Extend::ENABLE_PRODUCT_PROTECTION_CART_OFFER) === '1';
+    }
+    public function isProductProtectionMinicartOfferEnabled(): bool
+    {
+        return $this->getScopedConfigValue(Extend::ENABLE_PRODUCT_PROTECTION_MINICART_OFFER) ===
+            '1';
     }
 
     public function isProductProtectionPostPurchaseLeadModalOfferEnabled(): bool
     {
-        return $this->scopeConfig->getValue(
+        return $this->getScopedConfigValue(
             Extend::ENABLE_PRODUCT_PROTECTION_POST_PURCHASE_LEAD_MODAL_OFFER
         ) === '1';
     }
 
     public function isProductProtectionProductCatalogPageModalOfferEnabled(): bool
     {
-        return $this->scopeConfig->getValue(
+        return $this->getScopedConfigValue(
             Extend::ENABLE_PRODUCT_PROTECTION_PRODUCT_CATALOG_PAGE_MODAL_OFFER
         ) === '1';
+    }
+
+    /**
+     * Get Scoped Config Value
+     *
+     * @param string $configPath
+     * @return string
+     */
+    private function getScopedConfigValue(string $configPath): string
+    {
+        $scopeCode = $this->storeManager->getStore()->getCode();
+        $scopeType = ScopeInterface::SCOPE_STORES;
+        return $this->scopeConfig->getValue($configPath, $scopeType, $scopeCode);
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -42,7 +42,7 @@
             </group>
             <group id="product_protection" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Product Protection</label>
-                <field id="enable" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
+                <field id="enable" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable Product Protection (V2)</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <frontend_model>Extend\Integration\Model\Config\Frontend\EnableProductProtection</frontend_model>
@@ -53,13 +53,13 @@
                     <button_url>extend_integration/productprotection/create</button_url>
                     <frontend_model>Extend\Integration\Model\Config\Frontend\RecreatePPProduct</frontend_model>
                 </field>
-                <group id="offer_display_settings" translate="label" type="text" sortOrder="20" showInDefault="1">
+                <group id="offer_display_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <depends>
                         <field id="extend_plans/product_protection/enable">1</field>
                     </depends>
                     <attribute type="expanded">1</attribute>
                     <label>Offer Display Settings</label>
-                    <field id="enable_cart_offer" translate="label" type="select" sortOrder="10" showInDefault="1" canRestore="1">
+                    <field id="enable_cart_offer" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Display Product Protection Offers in Cart</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <depends>
@@ -67,7 +67,15 @@
                         </depends>
                         <comment>Display Extend Product Protection offers on each individual warrantable item in the customer's cart.</comment>
                     </field>
-                    <field id="enable_pdp_offer" translate="label" type="select" sortOrder="20" showInDefault="1" canRestore="1">
+                    <field id="enable_minicart_offer" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                        <label>Display Product Protection Offers in Mini Cart</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <depends>
+                            <field id="extend_plans/product_protection/enable">1</field>
+                        </depends>
+                        <comment>Display the Extend Product Protection offers for customers using the mini cart.</comment>
+                    </field>
+                    <field id="enable_pdp_offer" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Display Product Protection Offers on Product Display Page</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <depends>
@@ -75,7 +83,7 @@
                         </depends>
                         <comment>Display Extend Product Protection offers on the product display page for each warrantable item.</comment>
                     </field>
-                    <field id="enable_product_catalog_page_modal_offer" translate="label" type="select" sortOrder="30" showInDefault="1" canRestore="1">
+                    <field id="enable_product_catalog_page_modal_offer" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Display Product Protection Offers on Product Catalog Page</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <depends>
@@ -83,7 +91,7 @@
                         </depends>
                         <comment>Display the Extend Product Protection offer modal on the product catalog page after clicking “Add to cart“ for each warrantable item.</comment>
                     </field>
-                    <field id="enable_post_purchase_lead_modal_offer" translate="label" type="select" sortOrder="40" showInDefault="1" canRestore="1">
+                    <field id="enable_post_purchase_lead_modal_offer" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Display Post-Purchase Product Protection Offers</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -17,6 +17,7 @@
                 <enable>0</enable>
                 <offer_display_settings>
                     <enable_cart_offer>1</enable_cart_offer>
+                    <enable_minicart_offer>1</enable_minicart_offer>
                     <enable_pdp_offer>1</enable_pdp_offer>
                     <enable_product_catalog_page_modal_offer>1</enable_product_catalog_page_modal_offer>
                     <enable_post_purchase_lead_modal_offer>1</enable_post_purchase_lead_modal_offer>

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="category.product.addto">
-            <block class="Magento\Catalog\Block\Product\ProductList\Item\Block" after="-" ifconfig="extend_plans/product_protection/enable" name="extend.catalog.product.view.product-protection-modal-offer" template="Extend_Integration::catalog/product/view/product-protection-modal-offer.phtml">
+            <block class="Magento\Catalog\Block\Product\ProductList\Item\Block" after="-" ifconfig="extend/integration/enable" name="extend.catalog.product.view.product-protection-modal-offer" template="Extend_Integration::catalog/product/view/product-protection-modal-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/catalog_product_view_type_configurable.xml
+++ b/view/frontend/layout/catalog_product_view_type_configurable.xml
@@ -6,7 +6,7 @@
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.info.options.wrapper">
-            <block class="Magento\Catalog\Block\Product\View" ifconfig="extend_plans/product_protection/enable" after="-" name="extend.product.view.type.configurable.product-protection-offer" template="Extend_Integration::catalog/product/view/product-protection-offer.phtml">
+            <block class="Magento\Catalog\Block\Product\View" ifconfig="extend/integration/enable" after="-" name="extend.product.view.type.configurable.product-protection-offer" template="Extend_Integration::catalog/product/view/product-protection-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/catalog_product_view_type_grouped.xml
+++ b/view/frontend/layout/catalog_product_view_type_grouped.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.form.content">
-            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" ifconfig="extend_plans/product_protection/enable" after="-" name="extend.product.view.type.grouped.product-protection-offer" template="Extend_Integration::catalog/product/view/type/grouped/product-protection-offer.phtml">
+            <block class="Magento\GroupedProduct\Block\Product\View\Type\Grouped" ifconfig="extend/integration/enable" after="-" name="extend.product.view.type.grouped.product-protection-offer" template="Extend_Integration::catalog/product/view/type/grouped/product-protection-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/catalog_product_view_type_simple.xml
+++ b/view/frontend/layout/catalog_product_view_type_simple.xml
@@ -6,7 +6,7 @@
 <page layout="1column" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="product.info.form.content">
-            <block class="Magento\Catalog\Block\Product\View" before="-" ifconfig="extend_plans/product_protection/enable" name="extend.product.view.type.simple.product-protection-offer" template="Extend_Integration::catalog/product/view/product-protection-offer.phtml">
+            <block class="Magento\Catalog\Block\Product\View" before="-" ifconfig="extend/integration/enable" name="extend.product.view.type.simple.product-protection-offer" template="Extend_Integration::catalog/product/view/product-protection-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/checkout_cart_item_renderers.xml
+++ b/view/frontend/layout/checkout_cart_item_renderers.xml
@@ -6,28 +6,28 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.cart.item.renderers.default.actions">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend_plans/product_protection/offer_display_settings/enable_cart_offer" before="-" name="extend.cart.view.type.default.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend/integration/enable" before="-" name="extend.cart.view.type.default.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.simple.actions">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend_plans/product_protection/offer_display_settings/enable_cart_offer" before="-" name="extend.cart.view.type.simple.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend/integration/enable" before="-" name="extend.cart.view.type.simple.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.configurable.actions">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend_plans/product_protection/offer_display_settings/enable_cart_offer" before="-" name="extend.cart.view.type.configurable.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend/integration/enable" before="-" name="extend.cart.view.type.configurable.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>
             </block>
         </referenceBlock>
         <referenceBlock name="checkout.cart.item.renderers.grouped.actions">
-            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend_plans/product_protection/offer_display_settings/enable_cart_offer" before="-" name="extend.cart.view.type.grouped.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
+            <block class="Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic" ifconfig="extend/integration/enable" before="-" name="extend.cart.view.type.grouped.product-protection-offer" template="Extend_Integration::cart/item/renderer/actions/product-protection-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -16,7 +16,7 @@
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>
             </block>
-            <block name="extend.cart.normalized" template="Extend_Integration::cart/cart-normalization.phtml">
+            <block name="extend.cart.normalized" ifconfig="extend/integration/enable" template="Extend_Integration::cart/cart-normalization.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -6,12 +6,12 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block name="extend.minicart" ifconfig="extend_plans/product_protection/enable" template="Extend_Integration::cart/minicart-simple-offer.phtml">
+            <block name="extend.minicart" ifconfig="extend/integration/enable" template="Extend_Integration::cart/minicart-simple-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>
             </block>
-            <block name="extend.aftermarket-product-protection-modal-offer" ifconfig="extend_plans/product_protection/enable" template="Extend_Integration::catalog/product/view/aftermarket-product-protection-modal-offer.phtml">
+            <block name="extend.aftermarket-product-protection-modal-offer" ifconfig="extend/integration/enable" template="Extend_Integration::catalog/product/view/aftermarket-product-protection-modal-offer.phtml">
                 <arguments>
                     <argument name="viewModel" xsi:type="object">Extend\Integration\ViewModel\EnvironmentAndExtendStoreUuid</argument>
                 </arguments>

--- a/view/frontend/templates/cart/cart-normalization.phtml
+++ b/view/frontend/templates/cart/cart-normalization.phtml
@@ -4,11 +4,11 @@
  * See Extend-COPYING.txt for license details.
  */
 $viewModel = $this->getData('viewModel');
-$shouldBalanceCart = $viewModel->isCartBalancingEnabled();
+$shouldBalanceCart = $viewModel->isCartBalancingEnabled() && $viewModel->isExtendProductProtectionEnabled();
 ?>
 
 <script type="text/x-magento-init">
-    {
+  {
         "*":{
             "normalizeCart":
               {

--- a/view/frontend/templates/cart/minicart-simple-offer.phtml
+++ b/view/frontend/templates/cart/minicart-simple-offer.phtml
@@ -15,7 +15,7 @@ $shouldRender = $viewModel->isExtendProductProtectionEnabled() && $viewModel->is
     {
         "#extendMinicartSimpleOffer": {
             "minicartSimpleOffer": [
-              {
+                {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>"
                 }

--- a/view/frontend/templates/cart/minicart-simple-offer.phtml
+++ b/view/frontend/templates/cart/minicart-simple-offer.phtml
@@ -6,18 +6,21 @@
 $viewModel = $block->getData('viewModel');
 $extendStoreUuid = $viewModel->getExtendStoreUuid();
 $activeEnvironment = $viewModel->getActiveEnvironment();
+$shouldRender = $viewModel->isExtendProductProtectionEnabled() && $viewModel->isProductProtectionMinicartOfferEnabled();
 ?>
 
-<div id="extendMinicartSimpleOffer"></div>
-<script type="text/x-magento-init">
+<?php if ($shouldRender) : ?>
+  <div id="extendMinicartSimpleOffer"></div>
+  <script type="text/x-magento-init">
     {
         "#extendMinicartSimpleOffer": {
             "minicartSimpleOffer": [
-               {
+              {
                     "extendStoreUuid": "<?= $extendStoreUuid ?>",
                     "activeEnvironment": "<?= $activeEnvironment ?>"
                 }
             ]
         }
     }
-</script>
+  </script>
+<?php endif; ?>


### PR DESCRIPTION
# Description

* add minicart offer toggle because that wasn't in there yet
* set all `ifconfig`s for product protection offer-related templates to be contingent on the global, `default`-scoped module switch. that way
  * no templates are rendered/executed unless `extend is turned on` globally
  * individual offer templates control their own rendering logic, mainly by doing a scoped lookup using the relevant `store`'s `scopeCode`, and checking if a) PP is `on` for that store and b) the relevant offer display setting is `on` for that store
    * if no value is found persisted in the DB for that particular `scope` + `scopeCode` combo, magento automatically falls back to look at the value for the next higher scope, all the way up to the value specified in the `config.xml` file
* this means that PP can be turned off at the global level, but a single store can turn it on and control offer display settings granularly

## Ticket

https://helloextend.atlassian.net/browse/PAR-4934
https://helloextend.atlassian.net/browse/PAR-4944

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
