### PR TITLE
[PAR-4947] check for class type not exact class when deciding EA to call

### DIFF
--- a/Block/Sales/Totals/ShippingProtection.php
+++ b/Block/Sales/Totals/ShippingProtection.php
@@ -14,7 +14,6 @@ use Magento\Store\Model\Store;
 
 class ShippingProtection extends \Magento\Framework\View\Element\Template
 {
-
     /**
      * @var Order
      */
@@ -98,17 +97,17 @@ class ShippingProtection extends \Magento\Framework\View\Element\Template
     {
         $parentType = $parent->getType();
 
-        if ($parentType === \Magento\Sales\Block\Order\Totals::class) {
+        if (is_a($parentType, \Magento\Sales\Block\Order\Totals::class, true)) {
             $extensionAttributes = $parent->getOrder()->getExtensionAttributes();
             if ($extensionAttributes === null) {
                 $extensionAttributes = $this->orderExtensionFactory->create();
             }
-        } elseif ($parentType === \Magento\Sales\Block\Order\Invoice\Totals::class) {
+        } elseif (is_a($parentType, \Magento\Sales\Block\Order\Invoice\Totals::class, true)) {
             $extensionAttributes = $parent->getInvoice()->getExtensionAttributes();
             if ($extensionAttributes === null) {
                 $extensionAttributes = $this->invoiceExtensionFactory->create();
             }
-        } elseif ($parentType === \Magento\Sales\Block\Order\Creditmemo\Totals::class) {
+        } elseif (is_a($parentType, \Magento\Sales\Block\Order\Creditmemo\Totals::class, true)) {
             $extensionAttributes = $parent->getCreditmemo()->getExtensionAttributes();
             if ($extensionAttributes === null) {
                 $extensionAttributes = $this->creditmemoExtensionFactory->create();
@@ -120,7 +119,7 @@ class ShippingProtection extends \Magento\Framework\View\Element\Template
             return 0;
         }
 
-        return (float)$shippingProtection->getPrice();
+        return (float) $shippingProtection->getPrice();
     }
 
     /**
@@ -136,14 +135,12 @@ class ShippingProtection extends \Magento\Framework\View\Element\Template
         $this->_source = $parent->getSource();
 
         if ($this->getShippingProtection($parent) > 0) {
-            $total = new \Magento\Framework\DataObject(
-                [
-                    'code' => 'shipping_protection',
-                    'strong' => false,
-                    'value' => $this->getShippingProtection($parent),
-                    'label' => __(\Extend\Integration\Service\Extend::SHIPPING_PROTECTION_LABEL),
-                ]
-            );
+            $total = new \Magento\Framework\DataObject([
+                'code' => 'shipping_protection',
+                'strong' => false,
+                'value' => $this->getShippingProtection($parent),
+                'label' => __(\Extend\Integration\Service\Extend::SHIPPING_PROTECTION_LABEL),
+            ]);
 
             $parent->addTotal($total, 'shipping');
         }


### PR DESCRIPTION
# Description

This file, when determining whether to grab the order, invoice, or creditmemo extension attributes is looking for the exact parent class, but if a 3rd party module is used to display order emails, it won't be any of these classes and will throw an error.  The solution is to use the php function `is_a($class, \package\module\class::class)` instead of $class === \package\module\class::class, since the former will also compare $class against the compared class's parent class.  There is a high likelihood any 3rd party module would still extend the original classes since they need to use those functions found in the core Magento class to display these emails.

## Ticket

PAR-4947

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
