### PR TITLE
[PAR-4931] grab warranty item from quote and update qty if custom options match

### DIFF
--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -400,10 +400,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                     );
                 }
                 $item = $this->itemFactory->create();
-
-                if (isset($quantity)) {
-                    $item->setQty($quantity);
-                }
+                $item->setQty($quantity);
             }
 
             $product = $this->productRepository->get(Extend::WARRANTY_PRODUCT_SKU);

--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -364,6 +364,7 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                 );
             }
 
+            // Check whether a product protection item already exists in the cart
             if (!isset($item) || $item === false) {
                 foreach ($quote->getItems() as $quoteItem) {
                     if (
@@ -416,31 +417,19 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                     ->setIsSuperMode(true);
             }
 
-            $optionValues = [
-                self::PLAN_TYPE_CODE => $coverageType,
-                self::TERM_CODE => $term,
-                self::LIST_PRICE_CODE => $listPrice,
-                self::OFFER_PLAN_ID_CODE => $orderOfferPlanId,
-                self::LEAD_TOKEN => $leadToken,
-                self::ASSOCIATED_PRODUCT_SKU_CODE => $productId,
-                self::PLAN_ID_CODE => $planId,
-            ];
-
-            if ($leadToken) {
-                $this->setLeadTokenData(
-                    $optionValues,
-                    $quantity,
-                    $product,
-                    $item,
-                    $leadToken,
-                    $cartItemId,
-                    $term,
-                    $productId
-                );
-            } else {
-                $options = $this->createOptions($product, $item, $optionValues);
-                $item->setOptions($options);
-            }
+            $this->processOptions(
+                $cartItemId,
+                $leadToken,
+                $quantity,
+                $product,
+                $item,
+                $term,
+                $productId,
+                $planId,
+                $coverageType,
+                $listPrice,
+                $orderOfferPlanId
+            );
 
             // add the item to the quote and persist the quote so that the item <-> quote relationship is created
             $quote->addItem($item);
@@ -660,29 +649,45 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
     }
 
     /**
-     * This sets leadToken data on the quote item, if the leadToken is provided
+     * This function adds options unique to the Product Protection product as well as additional options customary to Magento
      *
-     * @param $optionValues
+     * @param $cartItemId
+     * @param $leadToken
      * @param $quantity
      * @param $product
      * @param $item
-     * @param $leadToken
-     * @param $cartItemId
      * @param $term
      * @param $productId
+     * @param $planId
+     * @param $listPrice
+     * @param $orderOfferPlanId
+     * @param $coverageType
      * @return void
      * @throws LocalizedException
      */
-    private function setLeadTokenData(
-        $optionValues,
+    private function processOptions(
+        $cartItemId,
+        $leadToken,
         $quantity,
         $product,
         $item,
-        $leadToken,
-        $cartItemId,
         $term,
-        $productId
+        $productId,
+        $planId,
+        $listPrice,
+        $orderOfferPlanId,
+        $coverageType
     ) {
+        $optionValues = [
+            self::PLAN_TYPE_CODE => $coverageType,
+            self::TERM_CODE => $term,
+            self::LIST_PRICE_CODE => $listPrice,
+            self::OFFER_PLAN_ID_CODE => $orderOfferPlanId,
+            self::LEAD_TOKEN => $leadToken,
+            self::ASSOCIATED_PRODUCT_SKU_CODE => $productId,
+            self::PLAN_ID_CODE => $planId,
+        ];
+
         $leadQuantity = null;
 
         if (isset($leadToken) && !isset($cartItemId)) {

--- a/Model/ProductProtection.php
+++ b/Model/ProductProtection.php
@@ -358,6 +358,20 @@ class ProductProtection extends \Magento\Framework\Model\AbstractModel implement
                 return;
             }
 
+            foreach ($quote->getItems() as $quoteItem) {
+                if (
+                    $quoteItem->getSku(Extend::WARRANTY_PRODUCT_SKU) &&
+                    $quoteItem->getOptionByCode('plan_id') &&
+                    $quoteItem->getOptionByCode('plan_id')->getValue() == $planId &&
+                    $quoteItem->getOptionByCode('associated_product_sku') &&
+                    $quoteItem->getOptionByCode('associated_product_sku')->getValue() == $productId
+                ) {
+                    $quoteItem->setQty($quoteItem->getQty() + $quantity);
+                    $item = $quoteItem;
+                    break;
+                }
+            }
+
             // if we are adding pp, or we didn't find an existing item, create a new one
             if (!isset($item) || $item === false) {
                 // ensure that we have the required properties to create the protection plan


### PR DESCRIPTION
# Description

This bugfix loops through the quote items and searches for current warranty items in the cart and if it finds a warranty cart item with the same associated product sku and warranty id as the request to this api, then it updates it's qty instead of adding a new instance of the warranty to cart.

## Ticket

PAR-4931

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
