### PR TITLE
[PAR-4961] skip over observers without instances *edge case*

### DIFF
--- a/Plugin/Event/ConfigPlugin.php
+++ b/Plugin/Event/ConfigPlugin.php
@@ -35,14 +35,16 @@ class ConfigPlugin
             foreach ($result as $resultItemKey => $resultItem) {
                 $thisClassPath = get_class($this);
                 $thisExplodedClass = explode('\\', (string) $thisClassPath);
-                $resultNameExplodedClass = explode('\\', $resultItem['instance']);
-                if (
-                    $thisExplodedClass[0] == $resultNameExplodedClass[0] &&
-                    $thisExplodedClass[1] == $resultNameExplodedClass[1] &&
-                    $this->scopeConfig->getValue(Extend::ENABLE_EXTEND) === '0'
-                ) {
-                    $resultItem['disabled'] = true;
-                    $result[$resultItemKey] = $resultItem;
+                if (isset($resultItem['instance'])) {
+                    $resultNameExplodedClass = explode('\\', $resultItem['instance']);
+                    if (
+                        $thisExplodedClass[0] == $resultNameExplodedClass[0] &&
+                        $thisExplodedClass[1] == $resultNameExplodedClass[1] &&
+                        $this->scopeConfig->getValue(Extend::ENABLE_EXTEND) === '0'
+                    ) {
+                        $resultItem['disabled'] = true;
+                        $result[$resultItemKey] = $resultItem;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

Very rarely an observer in the config xml (di.xml) will be missing an instance and this breaks out observers plugin (for the off switch)

## Ticket

PAR-4961

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
