### PR TITLE
[PAR-4936] Remove Source Item Logic from Product Installer

### DIFF
--- a/Setup/Model/ProductInstaller.php
+++ b/Setup/Model/ProductInstaller.php
@@ -32,9 +32,6 @@ use Magento\Framework\Module\Dir\Reader;
 use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Framework\Setup\Exception as SetupException;
-use Magento\Inventory\Model\SourceItemFactory;
-use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
-use Magento\InventoryApi\Api\SourceItemsSaveInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class ProductInstaller
@@ -54,8 +51,6 @@ class ProductInstaller
     private Reader $reader;
     private StoreManagerInterface $storeManager;
     private Registry $registry;
-    private SourceItemFactory $sourceItemFactory;
-    private SourceItemsSaveInterface $sourceItemsSave;
 
     public function __construct(
         DirectoryList $directoryList,
@@ -72,9 +67,7 @@ class ProductInstaller
         ProductResource $productResource,
         Reader $reader,
         StoreManagerInterface $storeManager,
-        Registry $registry,
-        SourceItemsSaveInterface $sourceItemsSave,
-        SourceItemFactory $sourceItemFactory
+        Registry $registry
     ) {
         $this->directoryList = $directoryList;
         $this->entryFactory = $entryFactory;
@@ -91,8 +84,6 @@ class ProductInstaller
         $this->productRepository = $productRepository;
         $this->reader = $reader;
         $this->registry = $registry;
-        $this->sourceItemsSave = $sourceItemsSave;
-        $this->sourceItemFactory = $sourceItemFactory;
     }
 
     public function createProduct($attributeSet)
@@ -101,7 +92,6 @@ class ProductInstaller
             if ($product = $this->createProtectionPlanProduct($attributeSet)) {
                 $this->addImageToPubMedia();
                 $this->processMediaGalleryEntry($this->getMediaImagePath(), $product->getSku());
-                $this->createSourceItem();
             }
         } catch (Exception $exception) {
             throw new Exception(
@@ -180,29 +170,6 @@ class ProductInstaller
         }
     }
 
-    /**
-     * Create inventory source item for PP
-     *
-     * @return void
-     * @throws SetupException
-     */
-    private function createSourceItem()
-    {
-        try {
-            $sourceItem = $this->sourceItemFactory->create();
-            $sourceItem->setSourceCode('default');
-            $sourceItem->setSku(Extend::WARRANTY_PRODUCT_SKU);
-            $sourceItem->setQuantity(1);
-            $sourceItem->setStatus(1);
-            $this->sourceItemsSave->execute([$sourceItem]);
-        } catch (Exception $exception) {
-            throw new SetupException(
-                new Phrase('There was a problem creating the source item: ', [
-                    $exception->getMessage(),
-                ])
-            );
-        }
-    }
     /**
      * Get image to pub media
      *


### PR DESCRIPTION
# Description

- Remove the inventory imports (source item related modules) so merchants with multi-source inventory (MSI) disabled can install the app
- It is quite common for Magento merchants to disable MSI modules when they depend on alternative, third-parties for inventory management
- Removed the part where we explicitly create the (default) source item for the PP product
- If MSI is enabled, it assigns a new product to the default source automatically anyways

## Ticket

https://helloextend.atlassian.net/browse/PAR-4936

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
