### PR TITLE
Patch Release : Update product-protection-simple-offer.js

### DIFF
--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -74,7 +74,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento', 'stringUtils'], function (
 
     const activeProductData = {
       referenceId: config[0].selectedProductSku,
-      price: parseInt(config[0].selectedProductPrice * 100).toPrecision(10),
+      price: parseInt((config[0].selectedProductPrice * 100).toPrecision(10)),
       category: config[0].productCategory,
       onAddToCart: handleAddToCartClick,
     }

--- a/view/frontend/web/js/view/cart/product-protection-simple-offer.js
+++ b/view/frontend/web/js/view/cart/product-protection-simple-offer.js
@@ -74,7 +74,7 @@ define(['cartUtils', 'extendSdk', 'ExtendMagento', 'stringUtils'], function (
 
     const activeProductData = {
       referenceId: config[0].selectedProductSku,
-      price: config[0].selectedProductPrice * 100,
+      price: parseInt(config[0].selectedProductPrice * 100).toPrecision(10),
       category: config[0].productCategory,
       onAddToCart: handleAddToCartClick,
     }


### PR DESCRIPTION
Fix offer payload

price errors out when ending in .99
price: 1898.9999999999998

# Description

Offer payload in the cart pulls an incorrect price when the product price ends with ".99"

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (new code changes but everything functions the same)

## Checklist

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have deployed and validated my code on a sandbox
- [ ] I have added tests that prove my fix is effective or that my feature works
